### PR TITLE
transit_vpc insane mode, create_vpc, GCP gw/spoke ha_zone supported added ; deprecated tunnel's cluster

### DIFF
--- a/Terraform_Scripts/gateway_gcp/README.md
+++ b/Terraform_Scripts/gateway_gcp/README.md
@@ -1,0 +1,9 @@
+## aviatrix_gateway
+---
+Testing GCP gateway full functionality
+
+**Note**
+* if testing HA, do not enable NAT (*enable_nat*), nor (*vpn_access*)
+  * GCP restriction: Can only have one SNAT gw per VPC network
+  * Aviatrix restriction: Peering HA is not supported on VPN gw (in general)
+* only testing updating GCP GW with HA parameters (creating a HA gw in a separate step)

--- a/Terraform_Scripts/gateway_gcp/gateway_gcp.tf
+++ b/Terraform_Scripts/gateway_gcp/gateway_gcp.tf
@@ -1,0 +1,59 @@
+resource "aviatrix_gateway" "gcloud_gw" {
+  cloud_type = 4
+  account_name = "GCPAccess"
+  gw_name = "testgcpvpngw" # gcloudgw
+  vpc_id = "gcptestvpc" # default
+  vpc_reg = "us-west2-a"
+  vpc_size = "f1-micro"
+  vpc_net = "10.168.0.0/20"
+
+  # enable_nat = "yes" # for gcp gw and spoke, only allowed if no HA (cannot have more than one SNAT GW)
+
+  ## failed to update Aviatrix VPN Gateway Authentication: Rest API set_vpn_gateway_authentication Get failed: [Aviatrix Error] VPC ID does not exist in DB
+  ## Please see id = 9377
+  ## remember to comment out; peeringHA not supported on VPN gw (in general)
+  # vpn_access = "yes"
+  # vpn_cidr = "192.168.43.0/24"
+  # enable_elb = "yes" # required parameter when cloud type is 4
+  # elb_name = "gcp-elb"
+  # saml_enabled = "yes"
+
+  ## Please see id = 9377
+  split_tunnel = "yes" # default is "yes"
+  # name_servers = "1.1.1.1,199.85.126.10"
+  # search_domains = "https://www.google.com"
+  # additional_cidrs = "172.32.0.0/16,10.11.0.0/16"
+
+  # otp_mode = "3"
+  # okta_token = "OOOOOOOOoooooooTTTTTTTTTTTTTTTTTTTTTTTTken"
+  # okta_url = "https://api-1234.okta.com"
+  # okta_username_suffix = "okta-suffiXXXXXXXXXXXXXXX"
+
+  # otp_mode = "2" # 2 = DUO ; 3 = Okta ; temporarily commented out because otp_mode lacking REST
+  # duo_integration_key = "DDDDDDDDDDDDDDDDDD"
+  # duo_secret_key = "QqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqXN2"
+  # duo_api_hostname = "api-22222222.duosecurity.com"
+  # duo_push_mode = "selective"
+
+  # enable_ldap = "yes"
+  # ldap_server = "1.2.3.4:567"
+  # ldap_bind_dn = "TTTTTTTTTEST\\Administratorr"
+  # ldap_password = "myLDAPpassword1234"
+  # ldap_base_dn = "DC=aviatrixtestt, DC=net"
+  # ldap_username_attribute = "manual"
+
+
+  ## Peering HA is not supported on VPN gw (in general)
+  # peering_ha_subnet = "us-west2-b" ## this is not used in GCP gateway
+  peering_ha_gw_size = "${var.gcp_ha_gw_size}"
+  peering_ha_zone = "${var.gcp_ha_gw_zone}"
+  # peering_ha_eip = "35.236.39.42" # not supported on GCP
+
+
+  # single_az_ha = "enabled" # not supported in GCP
+
+  allocate_new_eip = "on" # default is on
+  # eip = "35.236.3.191" # not supported on GCP
+
+  # tag_list = ["k1:v1"] # not supported on GCP
+}

--- a/Terraform_Scripts/gateway_gcp/gateway_gcp_testfiles/updateHAGWSize.tfvars
+++ b/Terraform_Scripts/gateway_gcp/gateway_gcp_testfiles/updateHAGWSize.tfvars
@@ -1,0 +1,4 @@
+## Test case 1: Update HAGW size and Zone; testing creating GW and updating HA attributes to create
+
+gcp_ha_gw_size = "f1-micro"
+gcp_ha_gw_zone = "us-west2-b"

--- a/Terraform_Scripts/gateway_gcp/provider.tf
+++ b/Terraform_Scripts/gateway_gcp/provider.tf
@@ -1,0 +1,6 @@
+# Enter your controller's IP, username and password to login
+provider "aviatrix" {
+  controller_ip = "1.2.3.4"
+  username = "admin"
+  password = "password"
+}

--- a/Terraform_Scripts/gateway_gcp/terraform.tfvars
+++ b/Terraform_Scripts/gateway_gcp/terraform.tfvars
@@ -1,0 +1,4 @@
+## initial creation
+
+gcp_ha_gw_size = ""
+gcp_ha_gw_zone = ""

--- a/Terraform_Scripts/gateway_gcp/vars.tf
+++ b/Terraform_Scripts/gateway_gcp/vars.tf
@@ -1,0 +1,2 @@
+variable "gcp_ha_gw_size" {}
+variable "gcp_ha_gw_zone" {}

--- a/Terraform_Scripts/peering_ha/peering_ha.tf
+++ b/Terraform_Scripts/peering_ha/peering_ha.tf
@@ -21,6 +21,6 @@ resource "aviatrix_tunnel" "peeringTunnel"{
            vpc_name2 = "${var.gateway_names[1]}"
            enable_ha = "${var.enable_ha}" # (optional)
           depends_on = ["aviatrix_gateway.GW"]
-          cluster = "${var.enable_cluster}" # (optional) whether to enable cluster peering
+          # cluster = "${var.enable_cluster}" # (optional) deprecated in 4.6
  # over_aws_peering = "no" # (deprecated) Use aws_peer resource instead
 }

--- a/Terraform_Scripts/peering_ha/terraform.tfvars
+++ b/Terraform_Scripts/peering_ha/terraform.tfvars
@@ -9,4 +9,4 @@ aws_vpc_public_cidr = ["10.0.0.0/24","11.0.0.0/24"]
 avx_peering_eip     = ["11.11.11.11", "12.12.12.12"]
 
 enable_ha           = "yes"
-enable_cluster      = "no"
+# enable_cluster      = "no"

--- a/Terraform_Scripts/peering_ha/vars.tf
+++ b/Terraform_Scripts/peering_ha/vars.tf
@@ -9,4 +9,4 @@ variable "aws_instance" {}
 variable "avx_peering_eip" { type = "list" }
 
 variable "enable_ha" {}
-variable "enable_cluster" {}
+# variable "enable_cluster" {}

--- a/Terraform_Scripts/transit_network/spoke_vpc_gcloud/disableSNAT.tfvars
+++ b/Terraform_Scripts/transit_network/spoke_vpc_gcloud/disableSNAT.tfvars
@@ -1,8 +1,8 @@
-## initial creation
+## Test case 1: Disable SNAT
 
 gcp_instance_size = "f1-micro"
 
 gcp_ha_gw_zone = ""
 gcp_ha_gw_size = ""
 
-toggle_snat = "yes"
+toggle_snat = "no"

--- a/Terraform_Scripts/transit_network/spoke_vpc_gcloud/enableHA.tfvars
+++ b/Terraform_Scripts/transit_network/spoke_vpc_gcloud/enableHA.tfvars
@@ -1,6 +1,6 @@
-## Test case 3: update gw size
+## Test case 2: enable HA
 
-gcp_instance_size = "g1-small"
+gcp_instance_size = "f1-micro"
 
 gcp_ha_gw_zone = "us-west2-b"
 gcp_ha_gw_size = "f1-micro"

--- a/Terraform_Scripts/transit_network/spoke_vpc_gcloud/spoke_vpc_gcloud.tf
+++ b/Terraform_Scripts/transit_network/spoke_vpc_gcloud/spoke_vpc_gcloud.tf
@@ -8,7 +8,8 @@ resource "aviatrix_spoke_vpc" "gcloud_spoke_gw" {
   vpc_reg = "us-west2-a" # is "Zone" in GUI
   vpc_size = "${var.gcp_instance_size}" # f1-micro ## g1-small
   subnet = "10.168.0.0/20" # 10.168.0.0/20 (us-west2) ## 10.138.0.0/20 (us-west1)
-  ha_subnet = "us-west2-b" # 10.168.0.0/20
+  # ha_subnet = "us-west2-b" # 10.168.0.0/20
+  ha_zone = "${var.gcp_ha_gw_zone}" ## added in 4.3
   ha_gw_size = "${var.gcp_ha_gw_size}"
   enable_nat = "${var.toggle_snat}" # cannot have SNAT enabled if you have HA-enabled
   # single_az_ha = "enabled" # used if not have HA-gw; not supported for Gcloud

--- a/Terraform_Scripts/transit_network/spoke_vpc_gcloud/updateHAGWSize.tfvars
+++ b/Terraform_Scripts/transit_network/spoke_vpc_gcloud/updateHAGWSize.tfvars
@@ -1,6 +1,8 @@
-## Test case 2: update ha-gw size
+## Test case 4: update HA GW size
 
-gcp_instance_size = "g1-small" # f1-micro -> g1-small
-gcp_ha_gw_size = "g1-small" # f1-micro -> g1-small
+gcp_instance_size = "g1-small"
+
+gcp_ha_gw_zone = "us-west2-b"
+gcp_ha_gw_size = "g1-small"
 
 toggle_snat = "no"

--- a/Terraform_Scripts/transit_network/spoke_vpc_gcloud/vars.tf
+++ b/Terraform_Scripts/transit_network/spoke_vpc_gcloud/vars.tf
@@ -1,4 +1,5 @@
 variable "gcp_instance_size" {}
 variable "gcp_ha_gw_size" {}
+variable "gcp_ha_gw_zone" {}
 
 variable "toggle_snat" {}

--- a/Terraform_Scripts/transit_network/transit_vpc/transit_vpc.tf
+++ b/Terraform_Scripts/transit_network/transit_vpc/transit_vpc.tf
@@ -16,7 +16,7 @@ resource "aviatrix_transit_vpc" "test_transit_gw" {
   vpc_reg           = "${var.aws_region}"
   vpc_size          = "${var.aws_instance}"
   subnet            = "${var.aws_vpc_public_cidr}"
-  # dns_server = # (optional) specify DNS IP, only required while using a custom private DNS for the VPC
+  # dns_server = # (optional) specify DNS IP, only required while using a custom private DNS for the VPC // deprecated 4.2
   ha_subnet = "${var.aviatrix_ha_subnet}"# (optional) HA subnet. Setting to empty/unset will disable HA. Setting to valid subnet will create an HA gateway in the subnet
   ha_gw_size = "${var.aviatrix_ha_gw_size}"# (optional) HA gw size. Mandatory if HA is enabled (ex. "t2.micro")
 

--- a/Terraform_Scripts/transit_network/transit_vpc_insane/provider.tf
+++ b/Terraform_Scripts/transit_network/transit_vpc_insane/provider.tf
@@ -1,0 +1,5 @@
+provider "aviatrix"  {
+  controller_ip = "1.2.3.4"
+  username = "admin"
+  password = "password"
+}

--- a/Terraform_Scripts/transit_network/transit_vpc_insane/transit_vpc_insane.tf
+++ b/Terraform_Scripts/transit_network/transit_vpc_insane/transit_vpc_insane.tf
@@ -1,0 +1,27 @@
+# Manage Aviatrix Transit Network Gateways
+
+# Create a transit VPC - insane mode enabled
+# Omit ha_subnet to launch transit VPC without HA.
+# HA subnet can later be added or deleted to enable/disable HA in transit VPC
+
+## Additional test case:
+# 1. attempt apply without specifying ha_gw_size; gw should not be created, error returned
+
+resource "aviatrix_transit_vpc" "test_transit_gw" {
+  cloud_type        = 1
+  account_name      = "PrimaryAccessAccount"
+  gw_name           = "transitGWInsane"
+  # enable_nat        = "${var.aviatrix_enable_nat}"
+  vpc_id            = "vpc-abc123"
+  vpc_reg           = "us-east-1"
+  vpc_size          = "c5.large" ## insane mode gateways must be at c5 series
+  subnet            = "10.0.1.64/26~~us-east-1a"
+  # ha_subnet = "10.0.1.128/26~~us-east-1a" # (optional) HA subnet. Setting to empty/unset will disable HA. Setting to valid subnet will create an HA gateway in the subnet
+  # ha_gw_size = "c5.large" # (optional) HA gw size. Mandatory if HA is enabled (ex. "c5.large")
+
+  # tag_list = ["k1:v1"] # optional
+  enable_hybrid_connection = "true" # (optional) enable to prep for TGW attachment; allows you to skip Step5 in TGW orchestrator
+  connected_transit = "yes" # (optional) specify connected transit status (yes or no)
+
+  insane_mode = "true" #  If enabled, will look for spare /26 segment to create a new subnet; must be formatted AWS: "10.0.0.0/26~~us-east1c
+}

--- a/Terraform_Scripts/vpc/vpc.tf
+++ b/Terraform_Scripts/vpc/vpc.tf
@@ -1,0 +1,36 @@
+provider "aviatrix"  {
+  controller_ip = "1.2.3.4"
+  username = "admin"
+  password = "password"
+}
+
+# Create a new VPC
+resource "aviatrix_vpc" "test_vpc" {
+  cloud_type = 1
+  account_name = "PrimaryAccessAccount"
+  region = "us-west-1"
+  name = "createVPCTest"
+  cidr = "11.11.11.11/24"
+  aviatrix_transit_vpc = false
+  aviatrix_firenet_vpc = false
+}
+
+resource "aviatrix_vpc" "test_vpc2" {
+  cloud_type = 1
+  account_name = "PrimaryAccessAccount"
+  region = "us-east-1"
+  name = "createVPCTest2"
+  cidr = "10.10.10.10/20"
+  aviatrix_transit_vpc = true
+  aviatrix_firenet_vpc = false
+}
+
+resource "aviatrix_vpc" "test_vpc3" {
+  cloud_type = 1
+  account_name = "PrimaryAccessAccount"
+  region = "us-west-2"
+  name = "createVPCTest3"
+  cidr = "13.13.13.13/24"
+  aviatrix_transit_vpc = false
+  aviatrix_firenet_vpc = true
+}


### PR DESCRIPTION
++ transit_vpc insane_mode (changes needed upcoming for 4.6)
++ create_vpc resource (FireNet added as well)

-- transit_vpc dns_server (clean up file; added 4.2 info)
-- tunnel cluster (deprecated in 4.6) (8814)

++ spoke_vpc GCP ha_zone (9213)
** gateway ha_subnet replaced with peering_ha_zone (9213)