### PR TITLE
TF 0.12: Fixes for S2C in R2.3 testbed ; Added R2.4 test cases ; Added R2.5 test cases

### DIFF
--- a/Terraform_Scripts_TF0.12/.gitignore
+++ b/Terraform_Scripts_TF0.12/.gitignore
@@ -1,6 +1,8 @@
 .DS_Store
 *_cred.tfvars
 *.json
+*.pem
+.terraform
 
 Jenkinsfile
 user_emails.tfvars

--- a/Terraform_Scripts_TF0.12/account_oracle/README.md
+++ b/Terraform_Scripts_TF0.12/account_oracle/README.md
@@ -1,0 +1,13 @@
+## aviatrix_account (Oracle)
+
+---
+
+### Usage
+```
+  terraform init
+  terraform apply -var-file=/path/oracle_account_cred.tfvars -auto-approve
+  terraform plan -var-file=/path/oracle_account_cred.tfvars -detailed-exitcode
+  terraform show
+
+  terraform destroy -var-file=oracle_account_cred.tfvars -auto-approve
+```

--- a/Terraform_Scripts_TF0.12/account_oracle/account_oracle.tf
+++ b/Terraform_Scripts_TF0.12/account_oracle/account_oracle.tf
@@ -1,0 +1,10 @@
+# Create Aviatrix Oracle account
+
+resource "aviatrix_account" "oci_access_account" {
+  cloud_type                    = 16
+  account_name                  = "OCIAccess"
+  oci_tenancy_id                = var.oci_tenancy_id
+  oci_user_id                   = var.oci_user_id
+  oci_compartment_id            = var.oci_compartment_id
+  oci_api_private_key_filepath  = var.oci_api_private_key
+}

--- a/Terraform_Scripts_TF0.12/account_oracle/provider.tf
+++ b/Terraform_Scripts_TF0.12/account_oracle/provider.tf
@@ -1,0 +1,5 @@
+provider "aviatrix"  {
+  controller_ip = var.aviatrix_controller_ip
+  username      = var.aviatrix_controller_username
+  password      = var.aviatrix_controller_password
+}

--- a/Terraform_Scripts_TF0.12/account_oracle/vars.tf
+++ b/Terraform_Scripts_TF0.12/account_oracle/vars.tf
@@ -1,0 +1,8 @@
+variable "aviatrix_controller_ip" {}
+variable "aviatrix_controller_username" {}
+variable "aviatrix_controller_password" {}
+
+variable "oci_tenancy_id" {}
+variable "oci_user_id" {}
+variable "oci_compartment_id" {}
+variable "oci_api_private_key" {}

--- a/Terraform_Scripts_TF0.12/firewall/firewall.tf
+++ b/Terraform_Scripts_TF0.12/firewall/firewall.tf
@@ -87,6 +87,7 @@ resource "aviatrix_firewall" "test_firewall_icmp" {
     port        = var.aviatrix_firewall_policy_port[6]
     action      = var.aviatrix_firewall_policy_action[0]
     log_enabled = var.aviatrix_firewall_policy_log_enable[0]
+    description = var.aviatrix_firewall_policy_description
   }
   depends_on = ["aviatrix_gateway.test_gateway2"]
 }

--- a/Terraform_Scripts_TF0.12/firewall/icmpEmpty.tfvars
+++ b/Terraform_Scripts_TF0.12/firewall/icmpEmpty.tfvars
@@ -1,4 +1,4 @@
-## initial creation
+## test case 1: change to icmp and test empty port as well as update description
 
 aviatrix_firewall_base_policy     = "allow-all"
 aviatrix_firewall_packet_logging  = true
@@ -38,3 +38,5 @@ aviatrix_firewall_policy_port             = ["69",
                                              "65535",
                                              "0:65535",
                                              ""]
+
+aviatrix_firewall_policy_description      = "icmp firewall rule UPDATED"

--- a/Terraform_Scripts_TF0.12/firewall/terraform.tfvars
+++ b/Terraform_Scripts_TF0.12/firewall/terraform.tfvars
@@ -38,3 +38,5 @@ aviatrix_firewall_policy_port             = ["69",
                                              "65535",
                                              "0:65535",
                                              "0:100"]
+
+aviatrix_firewall_policy_description      = "icmp firewall rule #1"

--- a/Terraform_Scripts_TF0.12/firewall/vars.tf
+++ b/Terraform_Scripts_TF0.12/firewall/vars.tf
@@ -23,3 +23,4 @@ variable "aviatrix_firewall_policy_action" {
 variable "aviatrix_firewall_policy_log_enable" {
   type = "list"
 }
+variable "aviatrix_firewall_policy_description" {}

--- a/Terraform_Scripts_TF0.12/fqdn/fqdn.tf
+++ b/Terraform_Scripts_TF0.12/fqdn/fqdn.tf
@@ -9,6 +9,11 @@ resource "aviatrix_gateway" "FQDN-GW" {
   gw_size       = "t2.micro"
   subnet        = "10.0.0.0/24"
   enable_snat   = true
+  enable_vpc_dns_server = false
+
+  lifecycle {
+    ignore_changes = [enable_vpc_dns_server]
+  }
 }
 
 resource "aviatrix_gateway" "FQDN-GW2" {
@@ -20,6 +25,11 @@ resource "aviatrix_gateway" "FQDN-GW2" {
   gw_size       = "t2.micro"
   subnet        = "10.202.0.0/16"
   enable_snat   = true
+  enable_vpc_dns_server = false
+
+  lifecycle {
+    ignore_changes = [enable_vpc_dns_server]
+  }
 }
 
 resource "aviatrix_fqdn" "FQDN-tag1" {

--- a/Terraform_Scripts_TF0.12/gateway/README.md
+++ b/Terraform_Scripts_TF0.12/gateway/README.md
@@ -30,6 +30,10 @@
                   -var-file=updateHAGWSize.tfvars \
                   -auto-approve
   terraform show
+  terraform apply -var-file=/path/provider_cred.tfvars \
+                  -var-file=enableDNSServer.tfvars \
+                  -auto-approve
+  terraform show
 
   terraform destroy -var-file=/path/provider_cred.tfvars -auto-approve
 ```

--- a/Terraform_Scripts_TF0.12/gateway/disableSNAT.tfvars
+++ b/Terraform_Scripts_TF0.12/gateway/disableSNAT.tfvars
@@ -4,3 +4,4 @@ aws_instance_size     = "t2.micro"
 aws_ha_gw_size        = "t2.micro"
 aws_gateway_tag_list  = []
 enable_snat           = false # disabled SNAT
+enable_vpc_dns_server = false

--- a/Terraform_Scripts_TF0.12/gateway/enableDNSServer.tfvars
+++ b/Terraform_Scripts_TF0.12/gateway/enableDNSServer.tfvars
@@ -1,0 +1,7 @@
+## Test case 5: enable_vpc_dns_server
+
+aws_instance_size     = "t2.small"
+aws_ha_gw_size        = "t2.small"
+aws_gateway_tag_list  = ["k1:v1", "k2:v2"]
+enable_snat           = false
+enable_vpc_dns_server = true # false -> true

--- a/Terraform_Scripts_TF0.12/gateway/gateway.tf
+++ b/Terraform_Scripts_TF0.12/gateway/gateway.tf
@@ -18,4 +18,6 @@ resource "aviatrix_gateway" "testGW1" {
   peering_ha_subnet   = "10.0.2.0/24"
   peering_ha_gw_size  = var.aws_ha_gw_size
   peering_ha_eip      = "18.204.25.144"
+
+  enable_vpc_dns_server = var.enable_vpc_dns_server
 }

--- a/Terraform_Scripts_TF0.12/gateway/terraform.tfvars
+++ b/Terraform_Scripts_TF0.12/gateway/terraform.tfvars
@@ -4,3 +4,4 @@ aws_instance_size     = "t2.micro"
 aws_ha_gw_size        = "t2.micro"
 aws_gateway_tag_list  = []
 enable_snat           = true
+enable_vpc_dns_server = false

--- a/Terraform_Scripts_TF0.12/gateway/updateGWSize.tfvars
+++ b/Terraform_Scripts_TF0.12/gateway/updateGWSize.tfvars
@@ -4,3 +4,4 @@ aws_instance_size     = "t2.small" # t2.micro -> t2.small
 aws_ha_gw_size        = "t2.micro"
 aws_gateway_tag_list  = ["k1:v1", "k2:v2"]
 enable_snat           = false
+enable_vpc_dns_server = false

--- a/Terraform_Scripts_TF0.12/gateway/updateHAGWSize.tfvars
+++ b/Terraform_Scripts_TF0.12/gateway/updateHAGWSize.tfvars
@@ -4,3 +4,4 @@ aws_instance_size     = "t2.small"
 aws_ha_gw_size        = "t2.small" # t2.micro -> t2.small
 aws_gateway_tag_list  = ["k1:v1", "k2:v2"]
 enable_snat           = false
+enable_vpc_dns_server = false

--- a/Terraform_Scripts_TF0.12/gateway/updateTagList.tfvars
+++ b/Terraform_Scripts_TF0.12/gateway/updateTagList.tfvars
@@ -4,3 +4,4 @@ aws_instance_size     = "t2.micro"
 aws_ha_gw_size        = "t2.micro"
 aws_gateway_tag_list  = ["k1:v1", "k2:v2"] # added tags
 enable_snat           = false
+enable_vpc_dns_server = false

--- a/Terraform_Scripts_TF0.12/gateway/vars.tf
+++ b/Terraform_Scripts_TF0.12/gateway/vars.tf
@@ -8,3 +8,4 @@ variable "aws_gateway_tag_list" {
   type = "list"
 }
 variable "enable_snat" {}
+variable "enable_vpc_dns_server" {}

--- a/Terraform_Scripts_TF0.12/gateway_oracle/README.md
+++ b/Terraform_Scripts_TF0.12/gateway_oracle/README.md
@@ -10,7 +10,7 @@
   terraform show
 
   terraform state rm aviatrix_gateway.oci_gateway
-  terraform import -var-file=/path/provider_cred.tfvars aviatrix_gateway.oci-gateway oci-gw
+  terraform import -var-file=/path/provider_cred.tfvars aviatrix_gateway.oci_gateway oci-gw
   terraform plan -var-file=/path/provider_cred.tfvars -detailed-exitcode
   terraform show
 

--- a/Terraform_Scripts_TF0.12/gateway_oracle/README.md
+++ b/Terraform_Scripts_TF0.12/gateway_oracle/README.md
@@ -1,0 +1,27 @@
+## aviatrix_gateway (OCI)
+
+---
+
+### Usage
+```
+  terraform init
+  terraform apply -var-file=/path/provider_cred.tfvars -auto-approve
+  terraform plan -var-file=/path/provider_cred.tfvars -detailed-exitcode
+  terraform show
+
+  terraform state rm aviatrix_gateway.oci_gateway
+  terraform import -var-file=/path/provider_cred.tfvars aviatrix_gateway.oci-gateway oci-gw
+  terraform plan -var-file=/path/provider_cred.tfvars -detailed-exitcode
+  terraform show
+
+  terraform apply -var-file=/path/provider_cred.tfvars \
+                  -var-file=updateGWSize.tfvars \
+                  -auto-approve
+  terraform show
+  terraform apply -var-file=/path/provider_cred.tfvars \
+                  -var-file=updateHAGWSize.tfvars \
+                  -auto-approve
+  terraform show
+
+  terraform destroy -var-file=/path/provider_cred.tfvars -auto-approve
+```

--- a/Terraform_Scripts_TF0.12/gateway_oracle/gateway_oracle.tf
+++ b/Terraform_Scripts_TF0.12/gateway_oracle/gateway_oracle.tf
@@ -1,0 +1,20 @@
+# Create and manage an Oracle Cloud gateway
+
+resource "aviatrix_gateway" "oci_gateway" {
+  cloud_type          = 16
+  account_name        = "OracleAccess"
+  gw_name             = "oci-gw"
+  vpc_id              = "OCI-VCN"
+  vpc_reg             = "us-ashburn-1"
+  gw_size             = "VM.Standard2.2"
+  subnet              = "123.101.0.0/16"
+
+  enable_snat         = false # updating/ enabling SNAT not supported for OCI (5.0)
+
+  allocate_new_eip    = true
+
+  peering_ha_subnet   = "123.101.0.0/16"
+  peering_ha_gw_size  = "VM.Standard2.2"
+
+  single_az_ha        = true
+}

--- a/Terraform_Scripts_TF0.12/gateway_oracle/gateway_oracle.tf
+++ b/Terraform_Scripts_TF0.12/gateway_oracle/gateway_oracle.tf
@@ -2,19 +2,19 @@
 
 resource "aviatrix_gateway" "oci_gateway" {
   cloud_type          = 16
-  account_name        = "OracleAccess"
+  account_name        = "OCIAccess"
   gw_name             = "oci-gw"
   vpc_id              = "OCI-VCN"
   vpc_reg             = "us-ashburn-1"
-  gw_size             = "VM.Standard2.2"
+  gw_size             = var.oci_gw_size
   subnet              = "123.101.0.0/16"
 
   enable_snat         = false # updating/ enabling SNAT not supported for OCI (5.0)
 
   allocate_new_eip    = true
 
-  peering_ha_subnet   = "123.101.0.0/16"
-  peering_ha_gw_size  = "VM.Standard2.2"
+  peering_ha_subnet   = var.oci_ha_gw_subnet
+  peering_ha_gw_size  = var.oci_ha_gw_size
 
   single_az_ha        = true
 }

--- a/Terraform_Scripts_TF0.12/gateway_oracle/provider.tf
+++ b/Terraform_Scripts_TF0.12/gateway_oracle/provider.tf
@@ -1,0 +1,5 @@
+provider "aviatrix"  {
+  controller_ip = var.aviatrix_controller_ip
+  username      = var.aviatrix_controller_username
+  password      = var.aviatrix_controller_password
+}

--- a/Terraform_Scripts_TF0.12/gateway_oracle/terraform.tfvars
+++ b/Terraform_Scripts_TF0.12/gateway_oracle/terraform.tfvars
@@ -1,0 +1,6 @@
+# initial creation
+
+oci_gw_size       = "VM.Standard2.2"
+
+oci_ha_gw_subnet  = "123.101.0.0/16"
+oci_ha_gw_size    = "VM.Standard2.2"

--- a/Terraform_Scripts_TF0.12/gateway_oracle/updateGWSize.tfvars
+++ b/Terraform_Scripts_TF0.12/gateway_oracle/updateGWSize.tfvars
@@ -1,0 +1,6 @@
+# test case 1: update gw size
+
+oci_gw_size       = "VM.Standard2.4"
+
+oci_ha_gw_subnet  = "123.101.0.0/16"
+oci_ha_gw_size    = "VM.Standard2.2"

--- a/Terraform_Scripts_TF0.12/gateway_oracle/updateHAGWSize.tfvars
+++ b/Terraform_Scripts_TF0.12/gateway_oracle/updateHAGWSize.tfvars
@@ -1,0 +1,6 @@
+# test case 2: update HA gw size
+
+oci_gw_size       = "VM.Standard2.4"
+
+oci_ha_gw_subnet  = "123.101.0.0/16"
+oci_ha_gw_size    = "VM.Standard2.4"

--- a/Terraform_Scripts_TF0.12/gateway_oracle/vars.tf
+++ b/Terraform_Scripts_TF0.12/gateway_oracle/vars.tf
@@ -2,5 +2,6 @@ variable "aviatrix_controller_ip" {}
 variable "aviatrix_controller_username" {}
 variable "aviatrix_controller_password" {}
 
-# variable "oci_ha_gw_subnet" {}
-# variable "oci_ha_gw_size" {}
+variable "oci_gw_size" {}
+variable "oci_ha_gw_subnet" {}
+variable "oci_ha_gw_size" {}

--- a/Terraform_Scripts_TF0.12/gateway_oracle/vars.tf
+++ b/Terraform_Scripts_TF0.12/gateway_oracle/vars.tf
@@ -1,0 +1,6 @@
+variable "aviatrix_controller_ip" {}
+variable "aviatrix_controller_username" {}
+variable "aviatrix_controller_password" {}
+
+# variable "oci_ha_gw_subnet" {}
+# variable "oci_ha_gw_size" {}

--- a/Terraform_Scripts_TF0.12/gateway_oracle_vpn/README.md
+++ b/Terraform_Scripts_TF0.12/gateway_oracle_vpn/README.md
@@ -1,0 +1,47 @@
+## aviatrix_gateway (Oracle vpn SAML)
+
+---
+
+### Usage
+```
+  terraform init
+  terraform apply -var-file=/path/provider_cred.tfvars -auto-approve
+  terraform plan -var-file=/path/provider_cred.tfvars -detailed-exitcode
+  terraform show
+
+  terraform state rm aviatrix_gateway.oci_vpn_gateway
+  terraform import -var-file=/path/provider_cred.tfvars aviatrix_gateway.oci_vpn_gateway oci-vpn-gw
+  terraform plan -var-file=/path/provider_cred.tfvars -detailed-exitcode
+  terraform show
+
+  terraform apply -var-file=/path/provider_cred.tfvars \
+                  -var-file=updateVPNCIDR.tfvars \
+                  -auto-approve
+  terraform show
+  terraform apply -var-file=/path/provider_cred.tfvars \
+                  -var-file=updateSearchDomain.tfvars \
+                  -auto-approve
+  terraform show
+  terraform apply -var-file=/path/provider_cred.tfvars \
+                  -var-file=updateCIDRs.tfvars \
+                  -auto-approve
+  terraform show
+  terraform apply -var-file=/path/provider_cred.tfvars \
+                  -var-file=updateNameServers.tfvars \
+                  -auto-approve
+  terraform show
+  terraform apply -var-file=/path/provider_cred.tfvars \
+                  -var-file=disableSingleAZHA.tfvars \
+                  -auto-approve
+  terraform show
+  terraform apply -var-file=/path/provider_cred.tfvars \
+                  -var-file=disableSplitTunnel.tfvars \
+                  -auto-approve
+  terraform show
+  terraform apply -var-file=/path/provider_cred.tfvars \
+                  -var-file=updateMaxConn.tfvars \
+                  -auto-approve
+  terraform show
+
+  terraform destroy -var-file=/path/provider_cred.tfvars -auto-approve
+```

--- a/Terraform_Scripts_TF0.12/gateway_oracle_vpn/disableSingleAZHA.tfvars
+++ b/Terraform_Scripts_TF0.12/gateway_oracle_vpn/disableSingleAZHA.tfvars
@@ -1,0 +1,11 @@
+## Test case 5: disable single AZ HA
+
+aviatrix_vpn_cidr = "192.168.43.0/25" # default is 192.168.43.0/24
+aviatrix_vpn_max_conn = 100
+
+aviatrix_vpn_split_tunnel                         = true
+aviatrix_vpn_split_tunnel_search_domain_list      = "https://duckduckgo.com/" # google -> duckduckgo
+aviatrix_vpn_split_tunnel_additional_cidrs_list   = "172.32.0.0/16" # removed 10.11.0.0/16
+aviatrix_vpn_split_tunnel_name_servers_list       = "1.1.1.1" # Cloudflare DNS, Norton SafeConnect // removed Norton
+
+aviatrix_single_az_ha = false # enabled -> disabled

--- a/Terraform_Scripts_TF0.12/gateway_oracle_vpn/disableSplitTunnel.tfvars
+++ b/Terraform_Scripts_TF0.12/gateway_oracle_vpn/disableSplitTunnel.tfvars
@@ -1,0 +1,11 @@
+## Test case 6: disable split tunnel
+
+aviatrix_vpn_cidr = "192.168.43.0/25" # default is 192.168.43.0/24
+aviatrix_vpn_max_conn = 100
+
+aviatrix_vpn_split_tunnel                         = false # yes -> no
+aviatrix_vpn_split_tunnel_search_domain_list      = "https://duckduckgo.com/" # google -> duckduckgo
+aviatrix_vpn_split_tunnel_additional_cidrs_list   = "172.32.0.0/16" # removed 10.11.0.0/16
+aviatrix_vpn_split_tunnel_name_servers_list       = "1.1.1.1" # Cloudflare DNS, Norton SafeConnect // removed Norton
+
+aviatrix_single_az_ha = false # enabled -> disabled

--- a/Terraform_Scripts_TF0.12/gateway_oracle_vpn/gateway_oracle_vpn.tf
+++ b/Terraform_Scripts_TF0.12/gateway_oracle_vpn/gateway_oracle_vpn.tf
@@ -1,0 +1,25 @@
+resource "aviatrix_gateway" "oci_vpn_gateway" {
+  cloud_type          = 16
+  account_name        = "OCIAccess"
+  gw_name             = "oci-vpn-gw"
+  vpc_id              = "OCI-VCN-phoenix"
+  vpc_reg              = "us-phoenix-1"
+  gw_size             = "VM.Standard2.2"
+  subnet              = "169.69.0.0/16"
+
+  enable_snat         = true
+  single_az_ha        = var.aviatrix_single_az_ha
+
+  vpn_access          = true
+  vpn_cidr            = var.aviatrix_vpn_cidr
+  # enable_elb          = true ## not supported by OCI
+  # elb_name            = "elb-oci-vpn-gw"
+  max_vpn_conn        = var.aviatrix_vpn_max_conn
+
+  split_tunnel        = var.aviatrix_vpn_split_tunnel
+  search_domains      = var.aviatrix_vpn_split_tunnel_search_domain_list
+  additional_cidrs    = var.aviatrix_vpn_split_tunnel_additional_cidrs_list
+  name_servers        = var.aviatrix_vpn_split_tunnel_name_servers_list
+
+  saml_enabled        = true
+}

--- a/Terraform_Scripts_TF0.12/gateway_oracle_vpn/provider.tf
+++ b/Terraform_Scripts_TF0.12/gateway_oracle_vpn/provider.tf
@@ -1,0 +1,5 @@
+provider "aviatrix"  {
+  controller_ip = var.aviatrix_controller_ip
+  username      = var.aviatrix_controller_username
+  password      = var.aviatrix_controller_password
+}

--- a/Terraform_Scripts_TF0.12/gateway_oracle_vpn/terraform.tfvars
+++ b/Terraform_Scripts_TF0.12/gateway_oracle_vpn/terraform.tfvars
@@ -1,0 +1,11 @@
+## initial creation
+
+aviatrix_vpn_cidr = "192.168.43.0/24"
+aviatrix_vpn_max_conn = 100
+
+aviatrix_vpn_split_tunnel                         = true
+aviatrix_vpn_split_tunnel_search_domain_list      = "https://www.google.com"
+aviatrix_vpn_split_tunnel_additional_cidrs_list   = "172.32.0.0/16,10.11.0.0/16"
+aviatrix_vpn_split_tunnel_name_servers_list       = "1.1.1.1,199.85.126.10" # Cloudflare DNS, Norton SafeConnect
+
+aviatrix_single_az_ha = true

--- a/Terraform_Scripts_TF0.12/gateway_oracle_vpn/updateCIDRs.tfvars
+++ b/Terraform_Scripts_TF0.12/gateway_oracle_vpn/updateCIDRs.tfvars
@@ -1,0 +1,11 @@
+## Test case 3: update additional CIDRs
+
+aviatrix_vpn_cidr = "192.168.43.0/25" # default is 192.168.43.0/24
+aviatrix_vpn_max_conn = 100
+
+aviatrix_vpn_split_tunnel                         = true
+aviatrix_vpn_split_tunnel_search_domain_list      = "https://duckduckgo.com/" # google -> duckduckgo
+aviatrix_vpn_split_tunnel_additional_cidrs_list   = "172.32.0.0/16" # removed 10.11.0.0/16
+aviatrix_vpn_split_tunnel_name_servers_list       = "1.1.1.1,199.85.126.10" # Cloudflare DNS, Norton SafeConnect
+
+aviatrix_single_az_ha = false

--- a/Terraform_Scripts_TF0.12/gateway_oracle_vpn/updateMaxConn.tfvars
+++ b/Terraform_Scripts_TF0.12/gateway_oracle_vpn/updateMaxConn.tfvars
@@ -1,0 +1,11 @@
+## Test case 7: update maximum vpn connections allowed to the gateway
+
+aviatrix_vpn_cidr = "192.168.43.0/25" # default is 192.168.43.0/24
+aviatrix_vpn_max_conn = 25
+
+aviatrix_vpn_split_tunnel                         = false # yes -> no
+aviatrix_vpn_split_tunnel_search_domain_list      = "https://duckduckgo.com/" # google -> duckduckgo
+aviatrix_vpn_split_tunnel_additional_cidrs_list   = "172.32.0.0/16" # removed 10.11.0.0/16
+aviatrix_vpn_split_tunnel_name_servers_list       = "1.1.1.1" # Cloudflare DNS, Norton SafeConnect // removed Norton
+
+aviatrix_single_az_ha = false # enabled -> disabled

--- a/Terraform_Scripts_TF0.12/gateway_oracle_vpn/updateNameServers.tfvars
+++ b/Terraform_Scripts_TF0.12/gateway_oracle_vpn/updateNameServers.tfvars
@@ -1,0 +1,11 @@
+## Test case 4: update name servers
+
+aviatrix_vpn_cidr = "192.168.43.0/25" # default is 192.168.43.0/24
+aviatrix_vpn_max_conn = 100
+
+aviatrix_vpn_split_tunnel                         = true
+aviatrix_vpn_split_tunnel_search_domain_list      = "https://duckduckgo.com/" # google -> duckduckgo
+aviatrix_vpn_split_tunnel_additional_cidrs_list   = "172.32.0.0/16" # removed 10.11.0.0/16
+aviatrix_vpn_split_tunnel_name_servers_list       = "1.1.1.1" # Cloudflare DNS, Norton SafeConnect // removed Norton
+
+aviatrix_single_az_ha = true

--- a/Terraform_Scripts_TF0.12/gateway_oracle_vpn/updateSearchDomain.tfvars
+++ b/Terraform_Scripts_TF0.12/gateway_oracle_vpn/updateSearchDomain.tfvars
@@ -1,0 +1,11 @@
+## Test case 2: update search domains
+
+aviatrix_vpn_cidr = "192.168.43.0/25" # default is 192.168.43.0/24
+aviatrix_vpn_max_conn = 100
+
+aviatrix_vpn_split_tunnel                         = true
+aviatrix_vpn_split_tunnel_search_domain_list      = "https://duckduckgo.com/" # google -> duckduckgo
+aviatrix_vpn_split_tunnel_additional_cidrs_list   = "172.32.0.0/16,10.11.0.0/16"
+aviatrix_vpn_split_tunnel_name_servers_list       = "1.1.1.1,199.85.126.10" # Cloudflare DNS, Norton SafeConnect
+
+aviatrix_single_az_ha = true

--- a/Terraform_Scripts_TF0.12/gateway_oracle_vpn/updateVPNCIDR.tfvars
+++ b/Terraform_Scripts_TF0.12/gateway_oracle_vpn/updateVPNCIDR.tfvars
@@ -1,0 +1,11 @@
+## Test case 1: update VPN CIDR
+
+aviatrix_vpn_cidr = "192.168.43.0/25" # default is 192.168.43.0/24
+aviatrix_vpn_max_conn = 100
+
+aviatrix_vpn_split_tunnel                         = true
+aviatrix_vpn_split_tunnel_search_domain_list      = "https://www.google.com"
+aviatrix_vpn_split_tunnel_additional_cidrs_list   = "172.32.0.0/16,10.11.0.0/16"
+aviatrix_vpn_split_tunnel_name_servers_list       = "1.1.1.1,199.85.126.10" # Cloudflare DNS, Norton SafeConnect
+
+aviatrix_single_az_ha = true

--- a/Terraform_Scripts_TF0.12/gateway_oracle_vpn/vars.tf
+++ b/Terraform_Scripts_TF0.12/gateway_oracle_vpn/vars.tf
@@ -1,0 +1,13 @@
+variable "aviatrix_controller_ip" {}
+variable "aviatrix_controller_username" {}
+variable "aviatrix_controller_password" {}
+
+variable "aviatrix_vpn_cidr" {}
+variable "aviatrix_vpn_max_conn" {}
+
+variable "aviatrix_vpn_split_tunnel" {}
+variable "aviatrix_vpn_split_tunnel_search_domain_list" {}
+variable "aviatrix_vpn_split_tunnel_additional_cidrs_list" {}
+variable "aviatrix_vpn_split_tunnel_name_servers_list" {}
+
+variable "aviatrix_single_az_ha" {}

--- a/Terraform_Scripts_TF0.12/site2cloud_unmapped/site2cloud_unmapped.tf
+++ b/Terraform_Scripts_TF0.12/site2cloud_unmapped/site2cloud_unmapped.tf
@@ -61,7 +61,7 @@ resource "aviatrix_site2cloud" "s2c_test" {
   connection_name               = "s2c_test_conn_name"
   connection_type               = "unmapped"
   remote_gateway_type           = "avx"
-  tunnel_type                   = "tcp"
+  tunnel_type                   = "udp"
   ha_enabled                    = true
 
   primary_cloud_gateway_name    = aviatrix_gateway.test_gateway1.gw_name
@@ -86,7 +86,7 @@ resource "aviatrix_site2cloud" "s2c_test2" {
   connection_name               = "s2c_test_conn_name_2"
   connection_type               = "unmapped"
   remote_gateway_type           = "avx"
-  tunnel_type                   = "tcp"
+  tunnel_type                   = "udp"
   ha_enabled                    = true
 
   primary_cloud_gateway_name    = aviatrix_gateway.test_gateway2.gw_name
@@ -111,7 +111,7 @@ resource "aviatrix_site2cloud" "s2c_test3" {
   connection_name               = "s2c_test_conn_name_3"
   connection_type               = "unmapped"
   remote_gateway_type           = "avx"
-  tunnel_type                   = "tcp"
+  tunnel_type                   = "udp"
   ha_enabled                    = true
 
   primary_cloud_gateway_name    = aviatrix_gateway.test_gateway3.gw_name
@@ -133,7 +133,7 @@ resource "aviatrix_site2cloud" "s2c_test4" {
   connection_name               = "s2c_test_conn_name_4"
   connection_type               = "unmapped"
   remote_gateway_type           = "avx"
-  tunnel_type                   = "tcp"
+  tunnel_type                   = "udp"
   ha_enabled                    = true
 
   primary_cloud_gateway_name    = aviatrix_gateway.test_gateway1.gw_name

--- a/Terraform_Scripts_TF0.12/site2cloud_unmapped/site2cloud_unmapped.tf
+++ b/Terraform_Scripts_TF0.12/site2cloud_unmapped/site2cloud_unmapped.tf
@@ -100,7 +100,7 @@ resource "aviatrix_site2cloud" "s2c_test2" {
   remote_subnet_cidr            = aviatrix_gateway.test_gateway1.subnet
   local_subnet_cidr             = aviatrix_gateway.test_gateway2.subnet
 
-  ssl_server_pool               = "192.168.45.0/24"
+  # ssl_server_pool               = "192.168.45.0/24"
   enable_dead_peer_detection    = true
 
   depends_on                    = ["aviatrix_site2cloud.s2c_test"]
@@ -122,7 +122,7 @@ resource "aviatrix_site2cloud" "s2c_test3" {
   remote_subnet_cidr            = aviatrix_gateway.test_gateway1.subnet
   local_subnet_cidr             = aviatrix_gateway.test_gateway3.subnet
 
-  ssl_server_pool               = "192.168.45.0/24"
+  # ssl_server_pool               = "192.168.45.0/24"
   enable_dead_peer_detection    = false
 
   depends_on                    = ["aviatrix_site2cloud.s2c_test2"]
@@ -144,7 +144,7 @@ resource "aviatrix_site2cloud" "s2c_test4" {
   remote_subnet_cidr            = aviatrix_gateway.test_gateway3.subnet
   local_subnet_cidr             = aviatrix_gateway.test_gateway1.subnet
 
-  ssl_server_pool               = "192.168.45.0/24"
+  # ssl_server_pool               = "192.168.45.0/24"
   enable_dead_peer_detection    = false
 
   depends_on = ["aviatrix_site2cloud.s2c_test3"]

--- a/Terraform_Scripts_TF0.12/spoke_gateway/README.md
+++ b/Terraform_Scripts_TF0.12/spoke_gateway/README.md
@@ -26,6 +26,10 @@
                   -var-file=updateHAGWSize.tfvars \
                   -auto-approve
   terraform show
+  terraform apply -var-file=/path/provider_cred.tfvars \
+                  -var-file=enableDNSServer.tfvars \
+                  -auto-approve
+  terraform show
 
   terraform destroy -var-file=/path/provider_cred.tfvars -auto-approve
 ```

--- a/Terraform_Scripts_TF0.12/spoke_gateway/enableDNSServer.tfvars
+++ b/Terraform_Scripts_TF0.12/spoke_gateway/enableDNSServer.tfvars
@@ -1,7 +1,7 @@
-## Test case 3: Update spoke_vpc's HA GW size
+## Test case 4: enable VPC dns server
 
 gw_size             = "c5.xlarge"
 aviatrix_ha_gw_size = "c5.xlarge"
 
 aviatrix_transit_gw = "transitGW2forSpoke"
-enable_vpc_dns_server = false
+enable_vpc_dns_server = true

--- a/Terraform_Scripts_TF0.12/spoke_gateway/spoke_gateway.tf
+++ b/Terraform_Scripts_TF0.12/spoke_gateway/spoke_gateway.tf
@@ -61,5 +61,6 @@ resource "aviatrix_spoke_gateway" "test_spoke_gateway" {
 
   transit_gw        = var.aviatrix_transit_gw
   tag_list          = ["k1:v1", "k2:v2"]
+  enable_vpc_dns_server = var.enable_vpc_dns_server
   depends_on        = ["aviatrix_transit_gateway.test_transit_gw1", "aviatrix_transit_gateway.test_transit_gw2"]
 }

--- a/Terraform_Scripts_TF0.12/spoke_gateway/terraform.tfvars
+++ b/Terraform_Scripts_TF0.12/spoke_gateway/terraform.tfvars
@@ -4,3 +4,4 @@ gw_size             = "c5.large"
 aviatrix_ha_gw_size = "c5.large"
 
 aviatrix_transit_gw = "transitGW1forSpoke"
+enable_vpc_dns_server = false

--- a/Terraform_Scripts_TF0.12/spoke_gateway/updateGWSize.tfvars
+++ b/Terraform_Scripts_TF0.12/spoke_gateway/updateGWSize.tfvars
@@ -4,3 +4,4 @@ gw_size             = "c5.xlarge"
 aviatrix_ha_gw_size = "c5.large"
 
 aviatrix_transit_gw = "transitGW2forSpoke"
+enable_vpc_dns_server = false

--- a/Terraform_Scripts_TF0.12/spoke_gateway/updateTransitGW.tfvars
+++ b/Terraform_Scripts_TF0.12/spoke_gateway/updateTransitGW.tfvars
@@ -4,3 +4,4 @@ gw_size             = "c5.large"
 aviatrix_ha_gw_size = "c5.large"
 
 aviatrix_transit_gw = "transitGW2forSpoke"
+enable_vpc_dns_server = false

--- a/Terraform_Scripts_TF0.12/spoke_gateway/vars.tf
+++ b/Terraform_Scripts_TF0.12/spoke_gateway/vars.tf
@@ -6,3 +6,4 @@ variable "gw_size" {}
 variable "aviatrix_ha_gw_size" {}
 
 variable "aviatrix_transit_gw" {}
+variable "enable_vpc_dns_server" {}

--- a/Terraform_Scripts_TF0.12/spoke_gateway_gcp/README.md
+++ b/Terraform_Scripts_TF0.12/spoke_gateway_gcp/README.md
@@ -30,6 +30,14 @@
                   -var-file=updateHAGWSize.tfvars \
                   -auto-approve
   terraform show
+  terraform apply -var-file=/path/provider_cred.tfvars \
+                  -var-file=attachTransitGW.tfvars \
+                  -auto-approve
+  terraform show
+  terraform apply -var-file=/path/provider_cred.tfvars \
+                  -var-file=switchTransitGW.tfvars \
+                  -auto-approve
+  terraform show
 
   terraform destroy -var-file=/path/provider_cred.tfvars -auto-approve
 ```

--- a/Terraform_Scripts_TF0.12/spoke_gateway_gcp/attachTransitGW.tfvars
+++ b/Terraform_Scripts_TF0.12/spoke_gateway_gcp/attachTransitGW.tfvars
@@ -1,4 +1,4 @@
-## Test case 4: update HA GW size
+## Test case 5: attach transit gw1
 
 gcp_instance_size = "n1-standard-2"
 
@@ -6,4 +6,4 @@ gcp_ha_gw_zone    = "us-west2-b"
 gcp_ha_gw_size    = "n1-standard-2"
 
 toggle_snat       = false
-attached_transit_gw = ""
+attached_transit_gw = "gcloudtransitgw1"

--- a/Terraform_Scripts_TF0.12/spoke_gateway_gcp/disableSNAT.tfvars
+++ b/Terraform_Scripts_TF0.12/spoke_gateway_gcp/disableSNAT.tfvars
@@ -6,3 +6,4 @@ gcp_ha_gw_zone    = ""
 gcp_ha_gw_size    = ""
 
 toggle_snat       = false
+attached_transit_gw = ""

--- a/Terraform_Scripts_TF0.12/spoke_gateway_gcp/enableHA.tfvars
+++ b/Terraform_Scripts_TF0.12/spoke_gateway_gcp/enableHA.tfvars
@@ -6,3 +6,4 @@ gcp_ha_gw_zone    = "us-west2-b"
 gcp_ha_gw_size    = "n1-standard-1"
 
 toggle_snat       = false
+attached_transit_gw = ""

--- a/Terraform_Scripts_TF0.12/spoke_gateway_gcp/spoke_gateway_gcp.tf
+++ b/Terraform_Scripts_TF0.12/spoke_gateway_gcp/spoke_gateway_gcp.tf
@@ -1,5 +1,35 @@
 # Manage Aviatrix spoke_gateway (Gcloud)
 
+resource "aviatrix_transit_gateway" "gcloud_transit_gw1" {
+  cloud_type          = 4
+  account_name        = "GCPAccess"
+  gw_name             = "gcloudtransitgw1"
+  vpc_id              = "gcptestvpc"
+  vpc_reg             = "us-central1-c"
+  gw_size             = "n1-standard-1"
+  subnet              = "10.128.0.0/20"
+  ha_subnet           = "10.128.0.0/20"
+  ha_gw_size          = "n1-standard-1"
+  enable_snat         = true
+  connected_transit   = true
+  enable_active_mesh  = false
+}
+
+resource "aviatrix_transit_gateway" "gcloud_transit_gw2" {
+  cloud_type          = 4
+  account_name        = "GCPAccess"
+  gw_name             = "gcloudtransitgw2"
+  vpc_id              = "default"
+  vpc_reg             = "us-east4"
+  gw_size             = "n1-standard-1"
+  subnet              = "10.150.0.0/20"
+  ha_subnet           = "10.150.0.0/20"
+  ha_gw_size          = "n1-standard-1"
+  enable_snat         = true
+  connected_transit   = true
+  enable_active_mesh  = false
+}
+
 resource "aviatrix_spoke_gateway" "gcloud_spoke_gw" {
   cloud_type      = 4
   account_name    = "GCPAccess"
@@ -13,4 +43,6 @@ resource "aviatrix_spoke_gateway" "gcloud_spoke_gw" {
   ha_gw_size      = var.gcp_ha_gw_size
   enable_snat     = var.toggle_snat
   enable_active_mesh = false
+  transit_gw      = var.attached_transit_gw
+  depends_on      = ["aviatrix_transit_gateway.gcloud_transit_gw1", "aviatrix_transit_gateway.gcloud_transit_gw2"]
 }

--- a/Terraform_Scripts_TF0.12/spoke_gateway_gcp/spoke_gateway_gcp.tf
+++ b/Terraform_Scripts_TF0.12/spoke_gateway_gcp/spoke_gateway_gcp.tf
@@ -1,34 +1,34 @@
 # Manage Aviatrix spoke_gateway (Gcloud)
 
-resource "aviatrix_transit_gateway" "gcloud_transit_gw1" {
-  cloud_type          = 4
-  account_name        = "GCPAccess"
-  gw_name             = "gcloudtransitgw1"
-  vpc_id              = "gcptestvpc"
-  vpc_reg             = "us-central1-c"
-  gw_size             = "n1-standard-1"
-  subnet              = "10.128.0.0/20"
-  ha_subnet           = "10.128.0.0/20"
-  ha_gw_size          = "n1-standard-1"
-  enable_snat         = true
-  connected_transit   = true
-  enable_active_mesh  = false
-}
-
-resource "aviatrix_transit_gateway" "gcloud_transit_gw2" {
-  cloud_type          = 4
-  account_name        = "GCPAccess"
-  gw_name             = "gcloudtransitgw2"
-  vpc_id              = "default"
-  vpc_reg             = "us-east4"
-  gw_size             = "n1-standard-1"
-  subnet              = "10.150.0.0/20"
-  ha_subnet           = "10.150.0.0/20"
-  ha_gw_size          = "n1-standard-1"
-  enable_snat         = true
-  connected_transit   = true
-  enable_active_mesh  = false
-}
+# resource "aviatrix_transit_gateway" "gcloud_transit_gw1" {
+#   cloud_type          = 4
+#   account_name        = "GCPAccess"
+#   gw_name             = "gcloudtransitgw1"
+#   vpc_id              = "gcptestvpc"
+#   vpc_reg             = "us-central1-c"
+#   gw_size             = "n1-standard-1"
+#   subnet              = "10.128.0.0/20"
+#   ha_subnet           = "10.128.0.0/20"
+#   ha_gw_size          = "n1-standard-1"
+#   enable_snat         = true
+#   connected_transit   = true
+#   enable_active_mesh  = false
+# }
+#
+# resource "aviatrix_transit_gateway" "gcloud_transit_gw2" {
+#   cloud_type          = 4
+#   account_name        = "GCPAccess"
+#   gw_name             = "gcloudtransitgw2"
+#   vpc_id              = "default"
+#   vpc_reg             = "us-east4"
+#   gw_size             = "n1-standard-1"
+#   subnet              = "10.150.0.0/20"
+#   ha_subnet           = "10.150.0.0/20"
+#   ha_gw_size          = "n1-standard-1"
+#   enable_snat         = true
+#   connected_transit   = true
+#   enable_active_mesh  = false
+# }
 
 resource "aviatrix_spoke_gateway" "gcloud_spoke_gw" {
   cloud_type      = 4
@@ -44,5 +44,5 @@ resource "aviatrix_spoke_gateway" "gcloud_spoke_gw" {
   enable_snat     = var.toggle_snat
   enable_active_mesh = false
   transit_gw      = var.attached_transit_gw
-  depends_on      = ["aviatrix_transit_gateway.gcloud_transit_gw1", "aviatrix_transit_gateway.gcloud_transit_gw2"]
+  # depends_on      = ["aviatrix_transit_gateway.gcloud_transit_gw1", "aviatrix_transit_gateway.gcloud_transit_gw2"]
 }

--- a/Terraform_Scripts_TF0.12/spoke_gateway_gcp/switchTransitGW.tfvars
+++ b/Terraform_Scripts_TF0.12/spoke_gateway_gcp/switchTransitGW.tfvars
@@ -1,4 +1,4 @@
-## Test case 4: update HA GW size
+## Test case 6: attach transit gw2
 
 gcp_instance_size = "n1-standard-2"
 
@@ -6,4 +6,4 @@ gcp_ha_gw_zone    = "us-west2-b"
 gcp_ha_gw_size    = "n1-standard-2"
 
 toggle_snat       = false
-attached_transit_gw = ""
+attached_transit_gw = "gcloudtransitgw2"

--- a/Terraform_Scripts_TF0.12/spoke_gateway_gcp/terraform.tfvars
+++ b/Terraform_Scripts_TF0.12/spoke_gateway_gcp/terraform.tfvars
@@ -6,3 +6,4 @@ gcp_ha_gw_zone    = ""
 gcp_ha_gw_size    = ""
 
 toggle_snat       = true
+attached_transit_gw = ""

--- a/Terraform_Scripts_TF0.12/spoke_gateway_gcp/updateGWSize.tfvars
+++ b/Terraform_Scripts_TF0.12/spoke_gateway_gcp/updateGWSize.tfvars
@@ -6,3 +6,4 @@ gcp_ha_gw_zone    = "us-west2-b"
 gcp_ha_gw_size    = "n1-standard-1"
 
 toggle_snat       = false
+attached_transit_gw = ""

--- a/Terraform_Scripts_TF0.12/spoke_gateway_gcp/vars.tf
+++ b/Terraform_Scripts_TF0.12/spoke_gateway_gcp/vars.tf
@@ -7,3 +7,4 @@ variable "gcp_ha_gw_size" {}
 variable "gcp_ha_gw_zone" {}
 
 variable "toggle_snat" {}
+variable "attached_transit_gw" {}

--- a/Terraform_Scripts_TF0.12/spoke_gateway_oracle/README.md
+++ b/Terraform_Scripts_TF0.12/spoke_gateway_oracle/README.md
@@ -1,0 +1,31 @@
+## aviatrix_spoke_gateway (OCI)
+
+---
+
+### Usage
+```
+  terraform init
+  terraform apply -var-file=/path/provider_cred.tfvars -auto-approve
+  terraform plan -var-file=/path/provider_cred.tfvars -detailed-exitcode
+  terraform show
+
+  terraform state rm aviatrix_spoke_gateway.oci_spoke_gateway
+  terraform import -var-file=/path/provider_cred.tfvars aviatrix_spoke_gateway.oci_spoke_gateway oci-spoke-gw
+  terraform plan -var-file=/path/provider_cred.tfvars -detailed-exitcode
+  terraform show
+
+  terraform apply -var-file=/path/provider_cred.tfvars \
+                  -var-file=updateTransitGW.tfvars \
+                  -auto-approve
+  terraform show
+  terraform apply -var-file=/path/provider_cred.tfvars \
+                  -var-file=updateGWSize.tfvars \
+                  -auto-approve
+  terraform show
+  terraform apply -var-file=/path/provider_cred.tfvars \
+                  -var-file=updateHAGWSize.tfvars \
+                  -auto-approve
+  terraform show
+
+  terraform destroy -var-file=/path/provider_cred.tfvars -auto-approve
+```

--- a/Terraform_Scripts_TF0.12/spoke_gateway_oracle/provider.tf
+++ b/Terraform_Scripts_TF0.12/spoke_gateway_oracle/provider.tf
@@ -1,0 +1,5 @@
+provider "aviatrix"  {
+  controller_ip = var.aviatrix_controller_ip
+  username      = var.aviatrix_controller_username
+  password      = var.aviatrix_controller_password
+}

--- a/Terraform_Scripts_TF0.12/spoke_gateway_oracle/spoke_gateway_oracle.tf
+++ b/Terraform_Scripts_TF0.12/spoke_gateway_oracle/spoke_gateway_oracle.tf
@@ -14,11 +14,29 @@ resource "aviatrix_transit_gateway" "oci_transit_gateway1" {
   gw_size             = "VM.Standard2.2"
   subnet              = "123.101.0.0/16"
 
-  # ha_subnet           = "123.101.0.0/16"
-  # ha_gw_size          = "VM.Standard2.2"
+  ha_subnet           = "123.101.0.0/16"
+  ha_gw_size          = "VM.Standard2.2"
 
-  enable_hybrid_connection  = false
-  connected_transit         = true
+  enable_hybrid_connection  = false # only supports cloud type 1
+  connected_transit         = true # (optional) specify connected transit status (yes or no)
+  enable_active_mesh        = false
+}
+
+resource "aviatrix_transit_gateway" "oci_transit_gateway2" {
+  cloud_type          = 16
+  account_name        = "OCIAccess"
+  gw_name             = "oci-transit-gw-for-spoke2"
+
+  vpc_id              = "OCI-VCN"
+  vpc_reg             = "us-ashburn-1"
+  gw_size             = "VM.Standard2.2"
+  subnet              = "123.101.0.0/16"
+
+  ha_subnet           = "123.101.0.0/16"
+  ha_gw_size          = "VM.Standard2.2"
+
+  enable_hybrid_connection  = false # only supports cloud type 1
+  connected_transit         = true # (optional) specify connected transit status (yes or no)
   enable_active_mesh        = false
 }
 
@@ -34,11 +52,11 @@ resource "aviatrix_spoke_gateway" "oci_spoke_gateway" {
   subnet            = "169.69.0.0/16"
   single_az_ha      = true
 
-  # ha_subnet         = "169.69.0.0/16"
-  # ha_gw_size        = var.ha_gw_size
-  enable_snat       = false
+  ha_subnet         = "169.69.0.0/16"
+  ha_gw_size        = var.ha_gw_size
+  enable_snat       = false # (Please disable AWS NAT instance before enabling this feature); not supported w insane mode
   enable_active_mesh= false
 
-  transit_gw        = var.transit_gw
-  depends_on        = ["aviatrix_transit_gateway.oci_transit_gateway1"]
+  transit_gw        = var.transit_gw # optional; comment out if want to test Update from no transitGW attachment to yes
+  depends_on        = ["aviatrix_transit_gateway.oci_transit_gateway1", "aviatrix_transit_gateway.oci_transit_gateway2"]
 }

--- a/Terraform_Scripts_TF0.12/spoke_gateway_oracle/spoke_gateway_oracle.tf
+++ b/Terraform_Scripts_TF0.12/spoke_gateway_oracle/spoke_gateway_oracle.tf
@@ -1,0 +1,44 @@
+## Initial creation
+# Launch a spoke VPC, and join with transit VPC.
+# Omit ha_subnet to launch spoke VPC without HA.
+# Omit transit_gw to launch spoke VPC without attaching with transit GW.
+# (R2.4 cannot test HA due to service limit issue on account)
+
+resource "aviatrix_transit_gateway" "oci_transit_gateway1" {
+  cloud_type          = 16
+  account_name        = "OCIAccess"
+  gw_name             = "oci-transit-gw-for-spoke"
+
+  vpc_id              = "OCI-VCN"
+  vpc_reg             = "us-ashburn-1"
+  gw_size             = "VM.Standard2.2"
+  subnet              = "123.101.0.0/16"
+
+  # ha_subnet           = "123.101.0.0/16"
+  # ha_gw_size          = "VM.Standard2.2"
+
+  enable_hybrid_connection  = false
+  connected_transit         = true
+  enable_active_mesh        = false
+}
+
+
+resource "aviatrix_spoke_gateway" "oci_spoke_gateway" {
+  cloud_type        = 16
+  account_name      = "OCIAccess"
+  gw_name           = "oci-spoke-gw"
+  vpc_id            = "OCI-VCN-phoenix"
+  vpc_reg           = "us-phoenix-1"
+  gw_size           = var.gw_size
+
+  subnet            = "169.69.0.0/16"
+  single_az_ha      = true
+
+  # ha_subnet         = "169.69.0.0/16"
+  # ha_gw_size        = var.ha_gw_size
+  enable_snat       = false
+  enable_active_mesh= false
+
+  transit_gw        = var.transit_gw
+  depends_on        = ["aviatrix_transit_gateway.oci_transit_gateway1"]
+}

--- a/Terraform_Scripts_TF0.12/spoke_gateway_oracle/terraform.tfvars
+++ b/Terraform_Scripts_TF0.12/spoke_gateway_oracle/terraform.tfvars
@@ -1,0 +1,6 @@
+# initial creation
+
+gw_size             = "VM.Standard2.2"
+# ha_gw_size          = "VM.Standard2.2"
+
+transit_gw          = "oci-transit-gw-for-spoke"

--- a/Terraform_Scripts_TF0.12/spoke_gateway_oracle/terraform.tfvars
+++ b/Terraform_Scripts_TF0.12/spoke_gateway_oracle/terraform.tfvars
@@ -1,6 +1,6 @@
 # initial creation
 
 gw_size             = "VM.Standard2.2"
-# ha_gw_size          = "VM.Standard2.2"
+ha_gw_size          = "VM.Standard2.2"
 
 transit_gw          = "oci-transit-gw-for-spoke"

--- a/Terraform_Scripts_TF0.12/spoke_gateway_oracle/updateGWSize.tfvars
+++ b/Terraform_Scripts_TF0.12/spoke_gateway_oracle/updateGWSize.tfvars
@@ -1,0 +1,6 @@
+# test case 2: update spoke gw size
+
+gw_size             = "VM.Standard2.4"
+ha_gw_size          = "VM.Standard2.2"
+
+transit_gw          = "oci-transit-gw-for-spoke2"

--- a/Terraform_Scripts_TF0.12/spoke_gateway_oracle/updateHAGWSize.tfvars
+++ b/Terraform_Scripts_TF0.12/spoke_gateway_oracle/updateHAGWSize.tfvars
@@ -1,0 +1,6 @@
+# test case 3: update spoke ha gw size
+
+gw_size             = "VM.Standard2.4"
+ha_gw_size          = "VM.Standard2.4"
+
+transit_gw          = "oci-transit-gw-for-spoke2"

--- a/Terraform_Scripts_TF0.12/spoke_gateway_oracle/updateTransitGW.tfvars
+++ b/Terraform_Scripts_TF0.12/spoke_gateway_oracle/updateTransitGW.tfvars
@@ -1,0 +1,6 @@
+# test case 1: update transit gw to attach
+
+gw_size             = "VM.Standard2.2"
+ha_gw_size          = "VM.Standard2.2"
+
+transit_gw          = "oci-transit-gw-for-spoke2"

--- a/Terraform_Scripts_TF0.12/spoke_gateway_oracle/vars.tf
+++ b/Terraform_Scripts_TF0.12/spoke_gateway_oracle/vars.tf
@@ -1,0 +1,8 @@
+variable "aviatrix_controller_ip" {}
+variable "aviatrix_controller_username" {}
+variable "aviatrix_controller_password" {}
+
+variable "gw_size" {}
+variable "ha_gw_size" {}
+
+variable "transit_gw" {}

--- a/Terraform_Scripts_TF0.12/transit_gateway/README.md
+++ b/Terraform_Scripts_TF0.12/transit_gateway/README.md
@@ -30,6 +30,10 @@
                   -var-file=updateHAGWSize.tfvars \
                   -auto-approve
   terraform show
+  terraform apply -var-file=/path/provider_cred.tfvars \
+                  -var-file=enableDNSServer.tfvars \
+                  -auto-approve
+  terraform show
 
   terraform destroy -var-file=/path/provider_cred.tfvars -auto-approve
 ```

--- a/Terraform_Scripts_TF0.12/transit_gateway/README.old.md
+++ b/Terraform_Scripts_TF0.12/transit_gateway/README.old.md
@@ -1,0 +1,21 @@
+Usage
+-----------
+After creating a base Transit GW (using terraform.tfvars), the test files should be run in this order:
+
+1. **switchConnectedTransit.tfvars**
+  * will turn off Connected Transit option
+2. **disableHybrid.tfvars**
+  * will disable "enable_hybrid_connection"; disables Step 5 in TGW Orchestrator > Plan
+3. **updateGWSize.tfvars**
+  * will change the transit GW's size from t2.micro to t2.small
+4. **updateHAGWSize.tfvars**
+  * will change the transit HA GW's size from t2.micro to t2.small
+
+
+* **emptycreation.tfvars**
+  * Please see Mantis: id=8192 for issue with ha_subnet, ha_gw_size
+  * Please see Mantis: id=8209 for issues with refresh and update tests
+  * (This is used to test invalid/ empty inputs; manual testing for Update cases as well)
+
+Running the scripts in this order will allow testing of manipulation of individual parameters.
+You can switch around orders to do combinations of different updates.

--- a/Terraform_Scripts_TF0.12/transit_gateway/disableHybrid.tfvars
+++ b/Terraform_Scripts_TF0.12/transit_gateway/disableHybrid.tfvars
@@ -5,3 +5,5 @@ aviatrix_ha_gw_size   = "c5.large"
 
 tgw_enable_hybrid             = false
 tgw_enable_connected_transit  = false
+
+enable_vpc_dns_server = false

--- a/Terraform_Scripts_TF0.12/transit_gateway/enableDNSServer.tfvars
+++ b/Terraform_Scripts_TF0.12/transit_gateway/enableDNSServer.tfvars
@@ -1,4 +1,4 @@
-## Test case 3: Update transit_vpc's HA_GW size
+## Test case 5: enable VPC dns server
 
 gw_size               = "c5.xlarge"
 aviatrix_ha_gw_size   = "c5.xlarge"
@@ -6,4 +6,4 @@ aviatrix_ha_gw_size   = "c5.xlarge"
 tgw_enable_hybrid             = false
 tgw_enable_connected_transit  = false
 
-enable_vpc_dns_server = false
+enable_vpc_dns_server = true

--- a/Terraform_Scripts_TF0.12/transit_gateway/switchConnectedTransit.tfvars
+++ b/Terraform_Scripts_TF0.12/transit_gateway/switchConnectedTransit.tfvars
@@ -5,3 +5,5 @@ aviatrix_ha_gw_size   = "c5.large"
 
 tgw_enable_hybrid             = true
 tgw_enable_connected_transit  = false
+
+enable_vpc_dns_server = false

--- a/Terraform_Scripts_TF0.12/transit_gateway/terraform.tfvars
+++ b/Terraform_Scripts_TF0.12/transit_gateway/terraform.tfvars
@@ -5,3 +5,5 @@ aviatrix_ha_gw_size   = "c5.large"
 
 tgw_enable_hybrid             = true
 tgw_enable_connected_transit  = true
+
+enable_vpc_dns_server = false

--- a/Terraform_Scripts_TF0.12/transit_gateway/transit_gateway.tf
+++ b/Terraform_Scripts_TF0.12/transit_gateway/transit_gateway.tf
@@ -21,4 +21,5 @@ resource "aviatrix_transit_gateway" "insane_transit_gw" {
   enable_hybrid_connection  = var.tgw_enable_hybrid
   connected_transit         = var.tgw_enable_connected_transit
   enable_active_mesh        = false
+  enable_vpc_dns_server     = var.enable_vpc_dns_server
 }

--- a/Terraform_Scripts_TF0.12/transit_gateway/updateGWSize.tfvars
+++ b/Terraform_Scripts_TF0.12/transit_gateway/updateGWSize.tfvars
@@ -5,3 +5,5 @@ aviatrix_ha_gw_size   = "c5.large"
 
 tgw_enable_hybrid             = false
 tgw_enable_connected_transit  = false
+
+enable_vpc_dns_server = false

--- a/Terraform_Scripts_TF0.12/transit_gateway/vars.tf
+++ b/Terraform_Scripts_TF0.12/transit_gateway/vars.tf
@@ -9,3 +9,5 @@ variable "aviatrix_ha_gw_size" {}
 
 variable "tgw_enable_hybrid" {}
 variable "tgw_enable_connected_transit" {}
+
+variable "enable_vpc_dns_server" {}

--- a/Terraform_Scripts_TF0.12/transit_gateway_gcp/README.md
+++ b/Terraform_Scripts_TF0.12/transit_gateway_gcp/README.md
@@ -1,0 +1,39 @@
+## aviatrix_transit_gateway (gcp)
+
+---
+
+### Usage
+```
+  terraform init
+  terraform apply -var-file=/path/provider_cred.tfvars -auto-approve
+  terraform plan -var-file=/path/provider_cred.tfvars -detailed-exitcode
+  terraform show
+
+  terraform state rm aviatrix_transit_gateway.gcp_transit_gateway
+  terraform import -var-file=/path/provider_cred.tfvars aviatrix_transit_gateway.gcp_transit_gateway gcloudtransitgw
+  terraform plan -var-file=/path/provider_cred.tfvars -detailed-exitcode
+  terraform show
+
+  terraform apply -var-file=/path/provider_cred.tfvars \
+                  -var-file=disableSNAT.tfvars \
+                  -auto-approve
+  terraform show
+  terraform apply -var-file=/path/provider_cred.tfvars \
+                  -var-file=disableConnectedTransit.tfvars \
+                  -auto-approve
+  terraform show
+  terraform apply -var-file=/path/provider_cred.tfvars \
+                  -var-file=enableActiveMesh.tfvars \
+                  -auto-approve
+  terraform show
+  terraform apply -var-file=/path/provider_cred.tfvars \
+                  -var-file=updateGWSize.tfvars \
+                  -auto-approve
+  terraform show
+  terraform apply -var-file=/path/provider_cred.tfvars \
+                  -var-file=updateHAGWSize.tfvars \
+                  -auto-approve
+  terraform show
+
+  terraform destroy -var-file=/path/provider_cred.tfvars -auto-approve
+```

--- a/Terraform_Scripts_TF0.12/transit_gateway_gcp/disableConnectedTransit.tfvars
+++ b/Terraform_Scripts_TF0.12/transit_gateway_gcp/disableConnectedTransit.tfvars
@@ -6,3 +6,4 @@ enable_active_mesh        = false
 
 gcp_gw_size     = "n1-standard-1"
 gcp_ha_gw_size  = "n1-standard-1"
+gcp_ha_gw_zone  = "us-central1-c"

--- a/Terraform_Scripts_TF0.12/transit_gateway_gcp/disableConnectedTransit.tfvars
+++ b/Terraform_Scripts_TF0.12/transit_gateway_gcp/disableConnectedTransit.tfvars
@@ -1,0 +1,8 @@
+# case 2: disable connected transit
+
+enable_snat               = false
+enable_connected_transit  = false
+enable_active_mesh        = false
+
+gcp_gw_size     = "n1-standard-1"
+gcp_ha_gw_size  = "n1-standard-1"

--- a/Terraform_Scripts_TF0.12/transit_gateway_gcp/disableSNAT.tfvars
+++ b/Terraform_Scripts_TF0.12/transit_gateway_gcp/disableSNAT.tfvars
@@ -6,3 +6,4 @@ enable_active_mesh        = false
 
 gcp_gw_size     = "n1-standard-1"
 gcp_ha_gw_size  = "n1-standard-1"
+gcp_ha_gw_zone  = "us-central1-c"

--- a/Terraform_Scripts_TF0.12/transit_gateway_gcp/disableSNAT.tfvars
+++ b/Terraform_Scripts_TF0.12/transit_gateway_gcp/disableSNAT.tfvars
@@ -1,0 +1,8 @@
+# case 1: disable SNAT
+
+enable_snat               = false
+enable_connected_transit  = true
+enable_active_mesh        = false
+
+gcp_gw_size     = "n1-standard-1"
+gcp_ha_gw_size  = "n1-standard-1"

--- a/Terraform_Scripts_TF0.12/transit_gateway_gcp/enableActiveMesh.tfvars
+++ b/Terraform_Scripts_TF0.12/transit_gateway_gcp/enableActiveMesh.tfvars
@@ -1,0 +1,8 @@
+# case 3: enable active mesh
+
+enable_snat               = false
+enable_connected_transit  = false
+enable_active_mesh        = true
+
+gcp_gw_size     = "n1-standard-1"
+gcp_ha_gw_size  = "n1-standard-1"

--- a/Terraform_Scripts_TF0.12/transit_gateway_gcp/enableActiveMesh.tfvars
+++ b/Terraform_Scripts_TF0.12/transit_gateway_gcp/enableActiveMesh.tfvars
@@ -6,3 +6,4 @@ enable_active_mesh        = true
 
 gcp_gw_size     = "n1-standard-1"
 gcp_ha_gw_size  = "n1-standard-1"
+gcp_ha_gw_zone  = "us-central1-c"

--- a/Terraform_Scripts_TF0.12/transit_gateway_gcp/provider.tf
+++ b/Terraform_Scripts_TF0.12/transit_gateway_gcp/provider.tf
@@ -1,0 +1,5 @@
+provider "aviatrix"  {
+  controller_ip = var.aviatrix_controller_ip
+  username      = var.aviatrix_controller_username
+  password      = var.aviatrix_controller_password
+}

--- a/Terraform_Scripts_TF0.12/transit_gateway_gcp/terraform.tfvars
+++ b/Terraform_Scripts_TF0.12/transit_gateway_gcp/terraform.tfvars
@@ -6,3 +6,4 @@ enable_active_mesh        = false
 
 gcp_gw_size     = "n1-standard-1"
 gcp_ha_gw_size  = "n1-standard-1"
+gcp_ha_gw_zone  = "us-central1-c"

--- a/Terraform_Scripts_TF0.12/transit_gateway_gcp/terraform.tfvars
+++ b/Terraform_Scripts_TF0.12/transit_gateway_gcp/terraform.tfvars
@@ -1,0 +1,8 @@
+# initial create
+
+enable_snat               = true
+enable_connected_transit  = true
+enable_active_mesh        = false
+
+gcp_gw_size     = "n1-standard-1"
+gcp_ha_gw_size  = "n1-standard-1"

--- a/Terraform_Scripts_TF0.12/transit_gateway_gcp/transit_gateway_gcp.tf
+++ b/Terraform_Scripts_TF0.12/transit_gateway_gcp/transit_gateway_gcp.tf
@@ -1,0 +1,17 @@
+resource "aviatrix_transit_gateway" "gcp_transit_gateway" {
+  cloud_type    = 4
+  account_name  = "GCPAccess"
+  gw_name       = "gcloudtransitgw"
+  vpc_id        = "gcptestvpc"
+  vpc_reg       = "us-central1-c"
+  gw_size       = var.gcp_gw_size
+  subnet        = "10.128.0.0/20"
+
+  ha_subnet     = "10.128.0.0/20"
+  ha_gw_size    = var.gcp_ha_gw_size
+
+  enable_snat   = var.enable_snat
+
+  connected_transit   = var.enable_connected_transit
+  enable_active_mesh  = var.enable_active_mesh
+}

--- a/Terraform_Scripts_TF0.12/transit_gateway_gcp/transit_gateway_gcp.tf
+++ b/Terraform_Scripts_TF0.12/transit_gateway_gcp/transit_gateway_gcp.tf
@@ -7,7 +7,7 @@ resource "aviatrix_transit_gateway" "gcp_transit_gateway" {
   gw_size       = var.gcp_gw_size
   subnet        = "10.128.0.0/20"
 
-  ha_subnet     = "10.128.0.0/20"
+  ha_zone       = var.gcp_ha_gw_zone
   ha_gw_size    = var.gcp_ha_gw_size
 
   enable_snat   = var.enable_snat

--- a/Terraform_Scripts_TF0.12/transit_gateway_gcp/updateGWSize.tfvars
+++ b/Terraform_Scripts_TF0.12/transit_gateway_gcp/updateGWSize.tfvars
@@ -1,0 +1,8 @@
+# case 4: update GW size
+
+enable_snat               = false
+enable_connected_transit  = false
+enable_active_mesh        = true
+
+gcp_gw_size     = "n1-standard-2"
+gcp_ha_gw_size  = "n1-standard-1"

--- a/Terraform_Scripts_TF0.12/transit_gateway_gcp/updateGWSize.tfvars
+++ b/Terraform_Scripts_TF0.12/transit_gateway_gcp/updateGWSize.tfvars
@@ -6,3 +6,4 @@ enable_active_mesh        = true
 
 gcp_gw_size     = "n1-standard-2"
 gcp_ha_gw_size  = "n1-standard-1"
+gpc_ha_gw_zone  = "us-central1-c"

--- a/Terraform_Scripts_TF0.12/transit_gateway_gcp/updateHAGWSize.tfvars
+++ b/Terraform_Scripts_TF0.12/transit_gateway_gcp/updateHAGWSize.tfvars
@@ -1,0 +1,8 @@
+# case 5: update HA GW size
+
+enable_snat               = false
+enable_connected_transit  = false
+enable_active_mesh        = true
+
+gcp_gw_size     = "n1-standard-2"
+gcp_ha_gw_size  = "n1-standard-2"

--- a/Terraform_Scripts_TF0.12/transit_gateway_gcp/updateHAGWSize.tfvars
+++ b/Terraform_Scripts_TF0.12/transit_gateway_gcp/updateHAGWSize.tfvars
@@ -6,3 +6,4 @@ enable_active_mesh        = true
 
 gcp_gw_size     = "n1-standard-2"
 gcp_ha_gw_size  = "n1-standard-2"
+gcp_ha_gw_zone  = "us-central1-c"

--- a/Terraform_Scripts_TF0.12/transit_gateway_gcp/vars.tf
+++ b/Terraform_Scripts_TF0.12/transit_gateway_gcp/vars.tf
@@ -8,3 +8,4 @@ variable "enable_active_mesh" {}
 
 variable "gcp_gw_size" {}
 variable "gcp_ha_gw_size" {}
+variable "gcp_ha_gw_zone" {}

--- a/Terraform_Scripts_TF0.12/transit_gateway_gcp/vars.tf
+++ b/Terraform_Scripts_TF0.12/transit_gateway_gcp/vars.tf
@@ -1,0 +1,10 @@
+variable "aviatrix_controller_ip" {}
+variable "aviatrix_controller_username" {}
+variable "aviatrix_controller_password" {}
+
+variable "enable_snat" {}
+variable "enable_connected_transit" {}
+variable "enable_active_mesh" {}
+
+variable "gcp_gw_size" {}
+variable "gcp_ha_gw_size" {}

--- a/Terraform_Scripts_TF0.12/transit_gateway_oracle/README.md
+++ b/Terraform_Scripts_TF0.12/transit_gateway_oracle/README.md
@@ -1,0 +1,31 @@
+## aviatrix_transit_gateway (OCI)
+
+---
+
+### Usage
+```
+  terraform init
+  terraform apply -var-file=/path/provider_cred.tfvars -auto-approve
+  terraform plan -var-file=/path/provider_cred.tfvars -detailed-exitcode
+  terraform show
+
+  terraform state rm aviatrix_transit_gateway.oci_transit_gateway
+  terraform import -var-file=/path/provider_cred.tfvars aviatrix_transit_gateway.oci_transit_gateway oci-transit-gw
+  terraform plan -var-file=/path/provider_cred.tfvars -detailed-exitcode
+  terraform show
+
+  terraform apply -var-file=/path/provider_cred.tfvars \
+                  -var-file=switchConnectedTransit.tfvars \
+                  -auto-approve
+  terraform show
+  terraform apply -var-file=/path/provider_cred.tfvars \
+                  -var-file=updateGWSize.tfvars \
+                  -auto-approve
+  terraform show
+  terraform apply -var-file=/path/provider_cred.tfvars \
+                  -var-file=updateHAGWSize.tfvars \
+                  -auto-approve
+  terraform show
+
+  terraform destroy -var-file=/path/provider_cred.tfvars -auto-approve
+```

--- a/Terraform_Scripts_TF0.12/transit_gateway_oracle/provider.tf
+++ b/Terraform_Scripts_TF0.12/transit_gateway_oracle/provider.tf
@@ -1,0 +1,5 @@
+provider "aviatrix"  {
+  controller_ip = var.aviatrix_controller_ip
+  username      = var.aviatrix_controller_username
+  password      = var.aviatrix_controller_password
+}

--- a/Terraform_Scripts_TF0.12/transit_gateway_oracle/switchConnectedTransit.tfvars
+++ b/Terraform_Scripts_TF0.12/transit_gateway_oracle/switchConnectedTransit.tfvars
@@ -1,0 +1,6 @@
+# test case 1: disable connected transit
+
+gw_size     = "VM.Standard2.2"
+ha_gw_size  = "VM.Standard2.2"
+
+tgw_enable_connected_transit  = false

--- a/Terraform_Scripts_TF0.12/transit_gateway_oracle/terraform.tfvars
+++ b/Terraform_Scripts_TF0.12/transit_gateway_oracle/terraform.tfvars
@@ -1,0 +1,6 @@
+# initial creation
+
+gw_size     = "VM.Standard2.2"
+ha_gw_size  = "VM.Standard2.2"
+
+tgw_enable_connected_transit  = true

--- a/Terraform_Scripts_TF0.12/transit_gateway_oracle/transit_gateway_oracle.tf
+++ b/Terraform_Scripts_TF0.12/transit_gateway_oracle/transit_gateway_oracle.tf
@@ -1,0 +1,20 @@
+# Manage Aviatrix Transit Network Gateways
+
+resource "aviatrix_transit_gateway" "oci_transit_gateway" {
+  cloud_type          = 16
+  account_name        = "OCIAccess"
+  gw_name             = "oci-transit-gw"
+  # enable_snat        = true # updating SNAT not supported by OCI
+  vpc_id              = "OCI-VCN"
+  vpc_reg             = "us-ashburn-1"
+  gw_size             = var.gw_size
+  subnet              = "123.101.0.0/16"
+
+  ha_subnet           = "123.101.0.0/16"
+  ha_gw_size          = var.ha_gw_size
+
+  enable_hybrid_connection  = false # only supports cloud type 1
+  connected_transit         = var.tgw_enable_connected_transit # (optional) specify connected transit status (yes or no)
+  enable_active_mesh        = false
+
+}

--- a/Terraform_Scripts_TF0.12/transit_gateway_oracle/updateGWSize.tfvars
+++ b/Terraform_Scripts_TF0.12/transit_gateway_oracle/updateGWSize.tfvars
@@ -1,0 +1,6 @@
+# test case 2: update gw size
+
+gw_size     = "VM.Standard2.4"
+ha_gw_size  = "VM.Standard2.2"
+
+tgw_enable_connected_transit  = false

--- a/Terraform_Scripts_TF0.12/transit_gateway_oracle/updateHAGWSize.tfvars
+++ b/Terraform_Scripts_TF0.12/transit_gateway_oracle/updateHAGWSize.tfvars
@@ -1,0 +1,6 @@
+# test case 3: update hagw size
+
+gw_size     = "VM.Standard2.4"
+ha_gw_size  = "VM.Standard2.4"
+
+tgw_enable_connected_transit  = false

--- a/Terraform_Scripts_TF0.12/transit_gateway_oracle/vars.tf
+++ b/Terraform_Scripts_TF0.12/transit_gateway_oracle/vars.tf
@@ -1,0 +1,8 @@
+variable "aviatrix_controller_ip" {}
+variable "aviatrix_controller_username" {}
+variable "aviatrix_controller_password" {}
+
+variable "gw_size" {}
+variable "ha_gw_size" {}
+
+variable "tgw_enable_connected_transit" {}


### PR DESCRIPTION
** S2C testing issues fixed for R2.3 release
++ GCP support for transit_gateway, spoke_gateway

(see 10645 for fix on GCP transit_gateway HA case)
(see 10692 for GCP attach transit to spoke case)

++ R2.4 features:
(see 10022 for OCI account, gateway, spoke, transit support)
** firewall policy: description attribute added

++ R2.5 features:
(see 10873 for enable/disable vpc dns server)
** added workaround for failing FQDN stage due to this feature
