### PR TITLE
update regression testbed to include aws gov

### DIFF
--- a/Regression_Testbed_TF_Module/README.md
+++ b/Regression_Testbed_TF_Module/README.md
@@ -21,6 +21,7 @@ This folder contains instructions and modules to create a Regression Testbed usi
 | [testbed-onprem](./modules/testbed-onprem) | Sets up an Aviatrix site2cloud connection with AWS VGW and onprem. | <ul><li>Public Key,</li><li>Aviatrix controller,</li><li>AWS account</li></ul> |
 | [testbed-vnet-arm](./modules/testbed-vnet-arm) | Creates an Azure RM VNET testbed environment | <ul><li>Public Key,</li><li>Azure RM account</li></ul> |
 | [testbed-vpc-aws](./modules/testbed-vpc-aws) | Creates an AWS VPC testbed environment | <ul><li>Public Key,</li><li>AWS account</li></ul> |
+| [testbed-vpc-aws-gov](./modules/testbed-vpc-aws-gov) | Creates an AWS GOV VPC testbed environment | <ul><li>Public Key,</li><li>AWS Gov account</li></ul> |
 | [testbed-vpc-gcp](./modules/testbed-vpc-gcp) | Creates a GCP VPC testbed environment | <ul><li>Public Key,</li><li>GCP account</li></ul> |
 | [testbed-windows-instance](./modules/testbed-windows-instance) | Creates an AWS VPC to launch a windows instance for RDP | <ul><li>Public Key,</li><li>AWS account</li></ul> |
 
@@ -36,8 +37,8 @@ There are 3 Phases:
   - Read the testbed-basic README.md for more information
   - initial `terraform apply`
 
-- **2nd:** Add Cross AWS/Azure RM vpcs.
-  - **optional**, uncomment  cross aws/arm modules and outputs to use
+- **2nd:** Add Cross AWS/AWS Gov/Azure RM vpcs.
+  - **optional**, uncomment  cross aws/aws gov/arm modules and outputs to use
 
 - **3rd:** Aviatrix tests
   - Add Aviatrix access accounts to Aviatrix controller

--- a/Regression_Testbed_TF_Module/examples/example_filled.tf
+++ b/Regression_Testbed_TF_Module/examples/example_filled.tf
@@ -1,3 +1,9 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# BE SURE TO CHANGE THE SOURCE PATH IN EACH MODULE
+# TO POINT TO THE CORRECT TESTBED MODULE FOLDER
+# FROM WHERE YOUR .TF FILE IS LOCATED
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # AWS Basic Creation module
@@ -127,6 +133,47 @@ module "testbed-basic" {
 #}
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# AWS Gov Account Module (Optional)
+# - VPCs with Ubuntu instance in AWS Gov account
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#module "aws-vpc-gov" {
+#  source          	          = "./Regression_Testbed_TF_module/modules/testbed-vpc-aws-gov"
+#  termination_protection      = local.terminal_protection
+#  resource_name_label         = local.resource_name_label
+#
+#  # AWS Gov Account
+#  aws_gov_access_key          = ""
+#  aws_gov_secret_key          = ""
+#
+#  # AWS Gov VPC setup
+#  vpc_public_key              = local.public_key
+#  pub_hostnum                 = local.pub_hostnum
+#  pri_hostnum                 = local.pri_hostnum
+#
+#  # US Gov West 1
+#  vpc_count_gov_west          = 1
+#  vpc_cidr_gov_west           = ["10.50.0.0/16"]
+#  pub_subnet1_cidr_gov_west   = ["10.50.5.0/24"]
+#  pub_subnet2_cidr_gov_west   = ["10.50.6.0/24"]
+#  pri_subnet_cidr_gov_west    = ["10.50.7.0/24"]
+#  pub_subnet1_az_gov_west     = ["us-gov-west-1b"]
+#  pub_subnet2_az_gov_west     = ["us-gov-west-1b"]
+#  pri_subnet_az_gov_west      = ["us-gov-west-1c"]
+#  ubuntu_ami_gov_west         = "ami-12531d73"
+#
+#  # US Gov East 1
+#  vpc_count_gov_east          = 1
+#  vpc_cidr_gov_east           = ["10.30.0.0/16"]
+#  pub_subnet1_cidr_gov_east   = ["10.30.5.0/24"]
+#  pub_subnet2_cidr_gov_east   = ["10.30.6.0/24"]
+#  pri_subnet_cidr_gov_east    = ["10.30.7.0/24"]
+#  pub_subnet1_az_gov_east     = ["us-gov-east-1a"]
+#  pub_subnet2_az_gov_east     = ["us-gov-east-1a"]
+#  pri_subnet_az_gov_east      = ["us-gov-east-1b"]
+#  ubuntu_ami_gov_east         = "ami-5ae2022b"
+#}
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Azure Vnet Module (Optional)
 # - VNETs with Ubuntu instances in specified region
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -160,7 +207,7 @@ module "testbed-basic" {
 #  region      = "us-central1"
 #}
 #
-#module "testbed-gcp" {
+#module "gcp-vpc" {
 #  source = "./Regression_Testbed_TF_Module/modules/testbed-vpc-gcp"
 #  vpc_count             = 1
 #  resource_name_label   = local.resource_name_label

--- a/Regression_Testbed_TF_Module/examples/testbed_outputs.tf
+++ b/Regression_Testbed_TF_Module/examples/testbed_outputs.tf
@@ -55,9 +55,9 @@ output "windows_key" {
  value = module.testbed-basic.windows_key
 }
 
-## ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-## AWS Cross Account Module (Optional)
-## ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# AWS Cross Account Module (Optional)
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #output "cross_aws_vpc_info" {
 #	value = [
 #    module.aws-cross-acct.vpc_name,
@@ -79,9 +79,27 @@ output "windows_key" {
 #  ]
 #}
 #
-## ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-## Azure Vnet Module (Optional)
-## ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# AWS Gov Account Module (Optional)
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#output "us-gov-west" {
+#  value = concat(
+#    module.aws-vpc-gov.gov_west_vpc_info,
+#    module.aws-vpc-gov.gov_west_subnet_info,
+#    module.aws-vpc-gov.gov_west_ubuntu_info
+#  )
+#}
+#output "us-gov-east" {
+#  value = concat(
+#    module.aws-vpc-gov.gov_east_vpc_info,
+#    module.aws-vpc-gov.gov_east_subnet_info,
+#    module.aws-vpc-gov.gov_east_ubuntu_info
+#  )
+#}
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Azure Vnet Module (Optional)
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #output "arm_vnet_info" {
 #	value = [
 #    module.arm-vnet.vnet_name,
@@ -108,22 +126,22 @@ output "windows_key" {
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #output "gcp_vpc_info" {
 #  value = [
-#    module.testbed-gcp.vpc_name,
-#    module.testbed-gcp.vpc_id
+#    module.gcp-vpc.vpc_name,
+#    module.gcp-vpc.vpc_id
 #  ]
 #}
 #output "gcp_subnet_info" {
 #	value = [
-#    module.testbed-gcp.subnet_name,
-#    module.testbed-gcp.subnet_cidr
+#    module.gcp-vpc.subnet_name,
+#    module.gcp-vpc.subnet_cidr
 #  ]
 #}
 #output "gcp_ubuntu_info" {
 #	value = [
-#    module.testbed-gcp.ubuntu_name,
-#    module.testbed-gcp.ubuntu_id,
-#    module.testbed-gcp.ubuntu_public_ip,
-#    module.testbed-gcp.ubuntu_private_ip
+#    module.gcp-vpc.ubuntu_name,
+#    module.gcp-vpc.ubuntu_id,
+#    module.gcp-vpc.ubuntu_public_ip,
+#    module.gcp-vpc.ubuntu_private_ip
 #  ]
 #}
 

--- a/Regression_Testbed_TF_Module/modules/testbed-basic/README.md
+++ b/Regression_Testbed_TF_Module/modules/testbed-basic/README.md
@@ -10,9 +10,6 @@ This Terraform configuration creates an AWS VPC testbed environment with ubuntu 
 - Existing AWS Key Pair
 - AMI with private key already within ubuntu instances
 
-### Set up Environment and Install terraform
-- To download and install Terraform, follow the Step 1 of the [Terraform tutorial on the Aviatrix documentation page](https://docs.aviatrix.com/HowTos/tf_aviatrix_howto.html).
-
 ### Usage
 
 1. Create testbed.tf and testbed_outputs.tf
@@ -22,7 +19,7 @@ This Terraform configuration creates an AWS VPC testbed environment with ubuntu 
 module "testbed-basic" {
   source = "<<main module path>> ie: ./testbed-basic"
   termination_protection      = <<true/false>>
-  resource_name_label         = ""<<input label for all resources>>"
+  resource_name_label         = "<<input label for all resources>>"
 
   # AWS Primary Account
   aws_primary_acct_access_key = "<<your aws primary access key>>"
@@ -349,54 +346,26 @@ Source IP that Windows instance security group will allow.
 AMI for the Windows instance to be created.
 
 ### Outputs
-- **us-west-1_vpc_id**
-- **us-west-2_vpc_id**
-- **us-east-1_vpc_id**
-- **us-east-2_vpc_id**
+- **west1_vpc_info**
+- **west2_vpc_info**
+- **east1_vpc_info**
+- **east2_vpc_info**
 
-Outputs the ID for all vpc's in the given regions.
+Outputs the vpc info (ID and name) for all vpc's in the given regions.
 
-- **us-west-1_vpc_name**
-- **us-west-2_vpc_name**
-- **us-east-1_vpc_name**
-- **us-east-2_vpc_name**
+- **west1_subnet_info**
+- **west2_subnet_info**
+- **east1_subnet_info**
+- **east2_subnet_info**
 
-Outputs the name for all vpc's in the given regions.
+Outputs the subnet info (name and cidr) for all subnets in the given regions.
 
-- **us-west-1_subnet_name**
-- **us-west-2_subnet_name**
-- **us-east-1_subnet_name**
-- **us-east-2_subnet_name**
+- **west1_ubuntu_info**
+- **west2_ubuntu_info**
+- **east1_ubuntu_info**
+- **east2_ubuntu_info**
 
-Outputs the name for all subnets in the given regions.
-
-- **us-west-1_subnet_cidr**
-- **us-west-2_subnet_cidr**
-- **us-east-1_subnet_cidr**
-- **us-east-2_subnet_cidr**
-
-Outputs the cidr for all subnets in the given regions.
-
-- **us-west-1_ubuntu_public_ip**
-- **us-west-2_ubuntu_public_ip**
-- **us-east-1_ubuntu_public_ip**
-- **us-east-2_ubuntu_public_ip**
-
-Outputs the public IP of the public ubuntu instances in the given regions.
-
-- **us-west-1_ubuntu_private_ip**
-- **us-west-2_ubuntu_private_ip**
-- **us-east-1_ubuntu_private_ip**
-- **us-east-2_ubuntu_private_ip**
-
-Outputs the private IP of the ubuntu instances in the given regions.
-
-- **us-west-1_ubuntu_id**
-- **us-west-2_ubuntu_id**
-- **us-east-1_ubuntu_id**
-- **us-east-2_ubuntu_id**
-
-Outputs the instance ID of the ubuntus in the given regions.
+Outputs the ubuntu info (name, id, public ip, and private ip) for all instances in the given regions.
 
 - **controller_public_ip**
 

--- a/Regression_Testbed_TF_Module/modules/testbed-vpc-aws-gov/README.md
+++ b/Regression_Testbed_TF_Module/modules/testbed-vpc-aws-gov/README.md
@@ -1,0 +1,137 @@
+## Aviatrix - Terraform Modules - AWS GOV VPC Setup
+
+### Description
+This Terraform module creates an AWS GOV VPC for the Regression Testbed environment. VPC includes: 2 public subnets, 1 private subnet, public rtb, private rtb, public ubuntu, private ubuntu. Ubuntu instances have an eip assigned to them and termination protection enabled. SSH and ICMP are open to 0.0.0.0/0. VPCs created in US-Gov-West and US-Gov-East.
+
+### Usage:
+To create a filled AWS GOV VPC:
+```
+module "aws-vpc-gov" {
+  source          	  = "./modules/testbed-vpc-aws-gov"
+  termination_protection      = <<true/false>>
+  resource_name_label         = "<<input label for all resources>>"
+
+  # AWS Gov Account
+  aws_gov_access_key = "<<your aws primary access key>>"
+  aws_gov_secret_key = "<<your aws secret key>>"
+
+  # AWS Gov VPC setup
+  vpc_public_key              = "<<your public key to access ubuntu instances>>"
+  pub_hostnum                 = <<input instance private ip hostnum>>
+  pri_hostnum                 = <<input instance private ip hostnum>>
+
+  # US Gov West 1
+  vpc_count_gov_west             = <<input number of vpcs>>
+  vpc_cidr_gov_west              = [<<insert cidrs>>]
+  pub_subnet1_cidr_gov_west      = [<<insert cidrs>>]
+  pub_subnet2_cidr_gov_west      = [<<insert cidrs>>]
+  pri_subnet_cidr_gov_west       = [<<insert cidrs>>]
+  pub_subnet1_az_gov_west        = [<<insert az's>>]
+  pub_subnet2_az_gov_west        = [<<insert az's>>]
+  pri_subnet_az_gov_west         = [<<insert az's>>]
+  ubuntu_ami_gov_west            = "<<insert ami>>"
+
+  # US Gov East 1
+  vpc_count_gov_east             = <<input number of vpcs>>
+  vpc_cidr_gov_east              = [<<insert cidrs>>]
+  pub_subnet1_cidr_gov_east      = [<<insert cidrs>>]
+  pub_subnet2_cidr_gov_east      = [<<insert cidrs>>]
+  pri_subnet_cidr_gov_east       = [<<insert cidrs>>]
+  pub_subnet1_az_gov_east        = [<<insert az's>>]
+  pub_subnet2_az_gov_east        = [<<insert az's>>]
+  pri_subnet_az_gov_east         = [<<insert az's>>]
+  ubuntu_ami_gov_east            = "<<insert ami>>"
+}
+```
+
+### Variables
+
+- **aws_gov_access_key**
+
+AWS Gov account's  access key.
+
+- **aws_gov_secret_key**
+
+AWS Gov account's  secret key.
+
+- **termination_protection**
+
+Whether to enable termination protection for ec2 instances.
+
+- **resource_name_label**
+
+The label for the resource name.
+
+- **vpc_public_key**
+
+Public key used for creating key pair for all instances.
+
+- **pub_hostnum**
+
+Number to be used for public ubuntu instance private ip host part. Must be a whole number that can be represented as a binary integer.
+
+- **pri_hostnum**
+
+Number to be used for private ubuntu instance private ip host part. Must be a whole number that can be represented as a binary integer.
+
+- **vpc_count_gov_west**
+- **vpc_count_gov_east**
+
+The number of vpcs to create in the given AWS region.
+
+- **vpc_cidr_gov_west**
+- **vpc_cidr_gov_east**
+
+The cidr of a vpc for a given region. List of strings.
+
+- **pub_subnet1_cidr_gov_west**
+- **pub_subnet1_cidr_gov_east**
+
+The cidr for public subnet 1 of a given region. List of strings.
+
+- **pub_subnet2_cidr_gov_west**
+- **pub_subnet2_cidr_gov_east**
+
+The cidr for public subnet 2 of a given region. List of strings.
+
+- **pri_subnet_cidr_gov_west**
+- **pri_subnet_cidr_gov_east**
+
+The cidr for a private subnet of a given region. List of strings.
+
+- **pub_subnet1_az_gov_west**
+- **pub_subnet1_az_gov_east**
+
+The availability zone for public subnet 1 of a given region. List of strings.
+
+- **pub_subnet2_az_gov_west**
+- **pub_subnet2_az_gov_east**
+
+The availability zone for public subnet 2 of a given region. List of strings.
+
+- **pri_subnet_az_gov_west**
+- **pri_subnet_az_gov_east**
+
+The availability zone for a private subnet of a given region. List of strings.
+
+- **ubuntu_ami_gov_west**
+- **ubuntu_ami_gov_east**
+
+AMI of the ubuntu instances.
+
+### Outputs
+
+- **gov_west_vpc_info**
+- **gov_east_vpc_info**
+
+Outputs the vpc info (ID and name) for all vpc's in the given regions.
+
+- **gov_west_subnet_info**
+- **gov_east_subnet_info**
+
+Outputs the subnet info (name and cidr) for all subnets in the given regions.
+
+- **gov_west_ubuntu_info**
+- **gov_east_ubuntu_info**
+
+Outputs the ubuntu info (name, id, public ip, and private ip) for all instances in the given regions.

--- a/Regression_Testbed_TF_Module/modules/testbed-vpc-aws-gov/main.tf
+++ b/Regression_Testbed_TF_Module/modules/testbed-vpc-aws-gov/main.tf
@@ -1,0 +1,66 @@
+# Terraform configuration file to set up the AWS environment in GOV cloud
+#
+# Each VPC: 2 public subnets, 1 private subnet, 2 public rtb, 1 private rtb
+#						1 public ubuntu instance, 1 private ubuntu instance
+#						eip assigned to instances
+#						temination protection enabled
+#						ssh and icmp open to 0.0.0.0/0
+
+provider "aws" {
+  version       = "~> 2.7"
+  region        = "us-gov-west-1"
+	access_key 		= var.aws_gov_access_key
+	secret_key 		= var.aws_gov_secret_key
+  alias         = "gov-west"
+}
+
+module "aws-vpc-gov-west" {
+  source          	    = "../testbed-vpc-aws"
+  providers = {
+    aws = aws.gov-west
+  }
+  vpc_count             = var.vpc_count_gov_west
+  resource_name_label   = var.resource_name_label
+	pub_hostnum						= var.pub_hostnum
+  pri_hostnum           = var.pri_hostnum
+  vpc_cidr              = var.vpc_cidr_gov_west
+  pub_subnet1_cidr      = var.pub_subnet1_cidr_gov_west
+  pub_subnet2_cidr      = var.pub_subnet2_cidr_gov_west
+  pri_subnet_cidr       = var.pri_subnet_cidr_gov_west
+  pub_subnet1_az      	= var.pub_subnet1_az_gov_west
+  pub_subnet2_az      	= var.pub_subnet2_az_gov_west
+  pri_subnet_az       	= var.pri_subnet_az_gov_west
+  ubuntu_ami            = var.ubuntu_ami_gov_west
+  public_key            = var.vpc_public_key
+	termination_protection = var.termination_protection
+}
+
+provider "aws" {
+  version       = "~> 2.7"
+  region        = "us-gov-east-1"
+	access_key 		= var.aws_gov_access_key
+	secret_key 		= var.aws_gov_secret_key
+  alias         = "gov-east"
+}
+
+module "aws-vpc-gov-east" {
+  source          	    = "../testbed-vpc-aws"
+  providers = {
+    aws = aws.gov-east
+  }
+  vpc_count             = var.vpc_count_gov_east
+  resource_name_label   = var.resource_name_label
+	pub_hostnum						= var.pub_hostnum
+  pri_hostnum           = var.pri_hostnum
+  vpc_cidr              = var.vpc_cidr_gov_east
+  pub_subnet1_cidr      = var.pub_subnet1_cidr_gov_east
+  pub_subnet2_cidr      = var.pub_subnet2_cidr_gov_east
+  pri_subnet_cidr       = var.pri_subnet_cidr_gov_east
+  pub_subnet1_az      	= var.pub_subnet1_az_gov_east
+  pub_subnet2_az      	= var.pub_subnet2_az_gov_east
+  pri_subnet_az       	= var.pri_subnet_az_gov_east
+  ubuntu_ami            = var.ubuntu_ami_gov_east
+  public_key            = var.vpc_public_key
+	instance_size	     		= "t3.nano"
+	termination_protection = var.termination_protection
+}

--- a/Regression_Testbed_TF_Module/modules/testbed-vpc-aws-gov/outputs.tf
+++ b/Regression_Testbed_TF_Module/modules/testbed-vpc-aws-gov/outputs.tf
@@ -1,0 +1,43 @@
+# Outputs for TF Regression Testbed AWS VPC environment setup
+
+output "gov_west_vpc_info" {
+	value = [
+		module.aws-vpc-gov-west.vpc_name,
+		module.aws-vpc-gov-west.vpc_id
+	]
+}
+output "gov_west_subnet_info" {
+	value = [
+		module.aws-vpc-gov-west.subnet_name,
+		module.aws-vpc-gov-west.subnet_cidr
+	]
+}
+output "gov_west_ubuntu_info" {
+	value = [
+		module.aws-vpc-gov-west.ubuntu_name,
+		module.aws-vpc-gov-west.ubuntu_id,
+		module.aws-vpc-gov-west.ubuntu_public_ip,
+		module.aws-vpc-gov-west.ubuntu_private_ip
+	]
+}
+
+output "gov_east_vpc_info" {
+	value = [
+		module.aws-vpc-gov-east.vpc_name,
+		module.aws-vpc-gov-east.vpc_id
+	]
+}
+output "gov_east_subnet_info" {
+	value = [
+		module.aws-vpc-gov-east.subnet_name,
+		module.aws-vpc-gov-east.subnet_cidr
+	]
+}
+output "gov_east_ubuntu_info" {
+	value = [
+		module.aws-vpc-gov-east.ubuntu_name,
+		module.aws-vpc-gov-east.ubuntu_id,
+		module.aws-vpc-gov-east.ubuntu_public_ip,
+		module.aws-vpc-gov-east.ubuntu_private_ip
+	]
+}

--- a/Regression_Testbed_TF_Module/modules/testbed-vpc-aws-gov/variables.tf
+++ b/Regression_Testbed_TF_Module/modules/testbed-vpc-aws-gov/variables.tf
@@ -1,0 +1,110 @@
+# Variable declarations for TF Regression Testbed AWS VPC environment setup
+
+# Providers
+variable "aws_gov_access_key" {
+  type        = string
+  description = "AWS Gov account's access key."
+}
+variable "aws_gov_secret_key" {
+  type        = string
+  description = "AWS Gov account's secret key."
+}
+
+variable "termination_protection" {
+	type				= bool
+	description = "Whether to enable termination protection for ec2 instances."
+}
+variable "resource_name_label" {
+	type				= string
+	description	= "The label for the resouce name."
+}
+
+# AWS VPC
+variable "vpc_public_key" {
+  type        = string
+  description = "Public key used for creating key pair for all instances."
+}
+variable "pub_hostnum" {
+  type        = number
+  description = "Number to be used for public ubuntu instance private ip host part. Must be a whole number that can be represented as a binary integer."
+}
+variable "pri_hostnum" {
+  type        = number
+  description = "Number to be used for private ubuntu instance private ip host part. Must be a whole number that can be represented as a binary integer."
+}
+
+# US-WEST-1 Region
+variable "vpc_count_gov_west" {
+  type        = number
+  description = "The number of vpcs to create in the given aws region."
+}
+variable "vpc_cidr_gov_west" {
+  type        = list(string)
+  description = "The cidr for a vpc."
+}
+variable "pub_subnet1_cidr_gov_west" {
+  type        = list(string)
+  description = "The cidr for public subnet 1."
+}
+variable "pub_subnet2_cidr_gov_west" {
+  type        = list(string)
+  description = "The cidr for public subnet 2."
+}
+variable "pri_subnet_cidr_gov_west" {
+  type        = list(string)
+  description = "The cidr for a private subnet."
+}
+variable "pub_subnet1_az_gov_west" {
+  type        = list(string)
+  description = "The availability zone for public subnet 1."
+}
+variable "pub_subnet2_az_gov_west" {
+  type        = list(string)
+  description = "The availability zone for public subnet 2."
+}
+variable "pri_subnet_az_gov_west" {
+  type        = list(string)
+  description = "The availability zone for a private subnet."
+}
+variable "ubuntu_ami_gov_west" {
+  type        = string
+  description = "AMI of the ubuntu instances"
+}
+
+# US-EAST-1 Region
+variable "vpc_count_gov_east" {
+  type        = number
+  description = "The number of vpcs to create in the given aws region."
+}
+variable "vpc_cidr_gov_east" {
+  type        = list(string)
+  description = "The cidr for a vpc."
+}
+variable "pub_subnet1_cidr_gov_east" {
+  type        = list(string)
+  description = "The cidr for public subnet 1."
+}
+variable "pub_subnet2_cidr_gov_east" {
+  type        = list(string)
+  description = "The cidr for public subnet 2."
+}
+variable "pri_subnet_cidr_gov_east" {
+  type        = list(string)
+  description = "The cidr for a private subnet."
+}
+variable "pub_subnet1_az_gov_east" {
+  type        = list(string)
+  description = "The availability zone for public subnet 1."
+}
+variable "pub_subnet2_az_gov_east" {
+  type        = list(string)
+  description = "The availability zone for public subnet 2."
+}
+variable "pri_subnet_az_gov_east" {
+  type        = list(string)
+  description = "The availability zone for a private subnet."
+}
+variable "ubuntu_ami_gov_east" {
+  type        = string
+  description = "AMI of the ubuntu instances"
+}

--- a/Regression_Testbed_TF_Module/modules/testbed-vpc-aws/README.md
+++ b/Regression_Testbed_TF_Module/modules/testbed-vpc-aws/README.md
@@ -79,6 +79,10 @@ Private subnet availability zone.
 
 AMI of the ubuntu instances
 
+- **instance_size**
+
+Size of AWS instances. Default is "t2.micro".
+
 - **termination_protection**
 
 Boolean value to enable termination protection of the ubuntu instances.

--- a/Regression_Testbed_TF_Module/modules/testbed-vpc-aws/main.tf
+++ b/Regression_Testbed_TF_Module/modules/testbed-vpc-aws/main.tf
@@ -109,7 +109,7 @@ resource "aws_instance" "public_instance" {
 	# Ubuntu
 	count												= var.vpc_count
 	ami													= var.ubuntu_ami
-	instance_type								= "t2.micro"
+	instance_type								= var.instance_size
 	disable_api_termination			= var.termination_protection
 	associate_public_ip_address = true
 	subnet_id										= aws_subnet.public_subnet1[count.index].id
@@ -125,7 +125,7 @@ resource "aws_instance" "private_instance" {
 	# Ubuntu
   count                       = var.vpc_count
   ami                         = var.ubuntu_ami
-  instance_type               = "t2.micro"
+  instance_type               = var.instance_size
 	disable_api_termination     = var.termination_protection
   subnet_id                   = aws_subnet.private_subnet[count.index].id
 	private_ip									= cidrhost(aws_subnet.private_subnet[count.index].cidr_block, var.pri_hostnum)

--- a/Regression_Testbed_TF_Module/modules/testbed-vpc-aws/variables.tf
+++ b/Regression_Testbed_TF_Module/modules/testbed-vpc-aws/variables.tf
@@ -52,6 +52,11 @@ variable "ubuntu_ami" {
 	type				= string
 	description = "AMI of the ubuntu instances"
 }
+variable "instance_size" {
+	type 				= string
+	description = "Size of AWS instance."
+	default 		= "t2.micro"
+}
 variable "termination_protection" {
 	type				= bool
 	description	= "Whether to disable api termination for the ubuntu instances."


### PR DESCRIPTION
- add variable for instance size in testbed-vpc-aws; default is t2.micro
- create testbed-vpc-aws-gov module
- update package readme
- update example files