### PR TITLE
change enable_snat to single_ip_snat for avtx gw

### DIFF
--- a/Regression_Testbed_TF_Module/modules/testbed-onprem-existing-vpc/main.tf
+++ b/Regression_Testbed_TF_Module/modules/testbed-onprem-existing-vpc/main.tf
@@ -9,7 +9,7 @@ resource "aviatrix_gateway" "avtx_gw" {
     vpc_reg             = data.aws_region.current.name
     gw_size             = "t3.micro"
     subnet              = var.pub_subnet_cidr
-    enable_snat         = true
+    single_ip_snat      = true
 }
 
 resource "aws_customer_gateway" "aws_cgw" {

--- a/Regression_Testbed_TF_Module/modules/testbed-onprem-new-vpc/main.tf
+++ b/Regression_Testbed_TF_Module/modules/testbed-onprem-new-vpc/main.tf
@@ -177,7 +177,7 @@ resource "aviatrix_gateway" "avtx_gw" {
     vpc_reg             = data.aws_region.current.name
     gw_size             = "t3.micro"
     subnet              = aws_subnet.public_subnet.cidr_block
-    enable_snat         = true
+    single_ip_snat      = true
 }
 
 resource "aws_customer_gateway" "aws_cgw" {


### PR DESCRIPTION
- enable_snat

If you are using/upgraded to Aviatrix Terraform Provider R2.10+, and a gateway with enable_snat set to true was originally created with a provider version <R2.10, you must do a ‘terraform refresh’ to update and apply the attribute’s value into the state. In addition, you must also change this attribute to single_ip_snat in your .tf file.