### PR TITLE
site_to_cloud, aws_instance type

### DIFF
--- a/Terraform_Solution_Tests/site2cloud/site2cloud.tf
+++ b/Terraform_Solution_Tests/site2cloud/site2cloud.tf
@@ -50,7 +50,7 @@ resource "aws_vpn_gateway" "vpn_gateway" {
 
 resource "aws_customer_gateway" "customer_gateway" {
   bgp_asn    = 65000
-  ip_address = aviatrix_gateway.AVX-GW.public_ip
+  ip_address = data.aviatrix_gateway.ag_data.public_ip
   type       = "ipsec.1"
 }
 

--- a/Terraform_Solution_Tests/site2cloud/site2cloud.tf
+++ b/Terraform_Solution_Tests/site2cloud/site2cloud.tf
@@ -37,7 +37,12 @@ resource "aviatrix_gateway" "AVX-GW" {
     ignore_changes = [enable_vpc_dns_server]
   }
 }
-
+    
+data "aviatrix_gateway" "ag_data" {
+  gw_name = "AVX-GW"
+  depends_on = [aviatrix_gateway.AVX-GW]
+}
+    
 #Create AWS VGW and attach to Site VPC
 resource "aws_vpn_gateway" "vpn_gateway" {
   vpc_id = module.aws-vpc.vpc_id[0]

--- a/Terraform_Solution_Tests/site2cloud/site2cloud.tf
+++ b/Terraform_Solution_Tests/site2cloud/site2cloud.tf
@@ -52,6 +52,7 @@ resource "aws_customer_gateway" "customer_gateway" {
   bgp_asn    = 65000
   ip_address = data.aviatrix_gateway.ag_data.public_ip
   type       = "ipsec.1"
+  depends_on = [aviatrix_gateway.AVX-GW]
 }
 
 resource "aws_vpn_connection" "main" {

--- a/Terraform_Solution_Tests/tgw_orchestrator_without_on-prem/tgw_orchestrator_without_on-prem.tf
+++ b/Terraform_Solution_Tests/tgw_orchestrator_without_on-prem/tgw_orchestrator_without_on-prem.tf
@@ -24,6 +24,7 @@ module "aws-vpc" {
   public_key      	  = "${file(var.public_key)}"
   termination_protection = false
   ubuntu_ami		      = "" # default empty will set to ubuntu 18.04 ami
+  instance_size       = contains(["us-east-2", "us-east-1"], var.aws_region) == true ? "t2.micro" : "t3.micro"
 }
 
 # Create an Aviatrix AWS TGW


### PR DESCRIPTION
- changes are for access public_ip of aviatrix-gateway (changed required for avx provider v2.14.0) - make the  aws_instance type generic based on aws-region in tgw_orchestrator_without_on-prem.