### PR TITLE
update testbed-vnet-arm module

### DIFF
--- a/Regression_Testbed_TF_Module/examples/example_filled.tf
+++ b/Regression_Testbed_TF_Module/examples/example_filled.tf
@@ -196,10 +196,12 @@ module "testbed-basic" {
 #	resource_name_label 	= local.resource_name_label
 #  pub_hostnum						= local.pub_hostnum
 #  pri_hostnum           = local.pri_hostnum
-#  vnet_cidr             = ["10.20.0.0/16", "10.30.0.0/16"]
-#	pub_subnet_cidr       = ["10.20.1.0/24", "10.30.3.0/24"]
-#	pri_subnet_cidr       = ["10.20.2.0/24", "10.30.4.0/24"]
-#	public_key 						= local.public_key
+#  vnet_cidr             = ["10.20.0.0/16"]
+#  pub_subnet1_cidr      = ["10.20.1.0/24"]
+#  pub_subnet2_cidr      = ["10.20.2.0/24"]
+#  pri_subnet1_cidr      = ["10.20.3.0/24"]
+#  pri_subnet2_cidr      = ["10.20.4.0/24"]
+  #	public_key 						= local.public_key
 #}
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Regression_Testbed_TF_Module/modules/testbed-vnet-arm/README.md
+++ b/Regression_Testbed_TF_Module/modules/testbed-vnet-arm/README.md
@@ -37,7 +37,7 @@ The number of vnets to create in the given arm region.
 
 - **resource_name_label**
 
-The label for the resource name.
+The label for the resource name. Resource name label can not include these characters: \` ~ ! @ # $ % ^ & * ( ) = + _ [ ] { } \\ | ; : ' \" , < > / ?
 
 - **pub_hostnum**
 

--- a/Regression_Testbed_TF_Module/modules/testbed-vnet-arm/main.tf
+++ b/Regression_Testbed_TF_Module/modules/testbed-vnet-arm/main.tf
@@ -26,8 +26,8 @@ resource "azurerm_virtual_network" "vnet" {
 
 # ARM Private route table
 resource "azurerm_route_table" "pri_rtb" {
-	count 												= var.vnet_count != 0 ? 1 : 0
-	name 													= "${var.resource_name_label}-pri-rtb"
+	count 												= var.vnet_count
+	name 													= "${var.resource_name_label}-pri-rtb${count.index}"
 	location 											= azurerm_resource_group.rg[0].location
 	resource_group_name         	= azurerm_resource_group.rg[0].name
 	disable_bgp_route_propagation	= false
@@ -45,19 +45,19 @@ resource "azurerm_route_table" "pri_rtb" {
 resource "azurerm_subnet_route_table_association" "pri_rtb_associate1" {
 	count 				 = var.vnet_count
 	subnet_id 		 = azurerm_subnet.private_subnet1[count.index].id
-	route_table_id = azurerm_route_table.pri_rtb[0].id
+	route_table_id = azurerm_route_table.pri_rtb[count.index].id
 }
 
 resource "azurerm_subnet_route_table_association" "pri_rtb_associate2" {
 	count 				 = var.vnet_count
 	subnet_id 		 = azurerm_subnet.private_subnet2[count.index].id
-	route_table_id = azurerm_route_table.pri_rtb[0].id
+	route_table_id = azurerm_route_table.pri_rtb[count.index].id
 }
 
 # ARM subnet
 resource "azurerm_subnet" "public_subnet1" {
 	count									= var.vnet_count
-	name									= "${var.resource_name_label}-pub1-subnet${count.index}"
+	name									= "${var.resource_name_label}-pub-subnet1-${count.index}"
 	resource_group_name		= azurerm_resource_group.rg[0].name
 	virtual_network_name	= azurerm_virtual_network.vnet[count.index].name
 	address_prefix				= var.pub_subnet1_cidr[count.index]
@@ -69,7 +69,7 @@ resource "azurerm_subnet" "public_subnet1" {
 
 resource "azurerm_subnet" "public_subnet2" {
 	count									= var.vnet_count
-	name									= "${var.resource_name_label}-pub2-subnet${count.index}"
+	name									= "${var.resource_name_label}-pub-subnet2-${count.index}"
 	resource_group_name		= azurerm_resource_group.rg[0].name
 	virtual_network_name	= azurerm_virtual_network.vnet[count.index].name
 	address_prefix				= var.pub_subnet2_cidr[count.index]
@@ -81,7 +81,7 @@ resource "azurerm_subnet" "public_subnet2" {
 
 resource "azurerm_subnet" "private_subnet1" {
 	count									= var.vnet_count
-	name									= "${var.resource_name_label}-pri1-subnet${count.index}"
+	name									= "${var.resource_name_label}-pri-subnet1-${count.index}"
 	resource_group_name		= azurerm_resource_group.rg[0].name
 	virtual_network_name	=	azurerm_virtual_network.vnet[count.index].name
 	address_prefix				=	var.pri_subnet1_cidr[count.index]
@@ -93,7 +93,7 @@ resource "azurerm_subnet" "private_subnet1" {
 
 resource "azurerm_subnet" "private_subnet2" {
 	count									= var.vnet_count
-	name									= "${var.resource_name_label}-pri2-subnet${count.index}"
+	name									= "${var.resource_name_label}-pri-subnet2-${count.index}"
 	resource_group_name		= azurerm_resource_group.rg[0].name
 	virtual_network_name	=	azurerm_virtual_network.vnet[count.index].name
 	address_prefix				=	var.pri_subnet2_cidr[count.index]
@@ -106,7 +106,7 @@ resource "azurerm_subnet" "private_subnet2" {
 # ARM Network SG
 resource "azurerm_network_security_group" "network_sg" {
 	count 							= var.vnet_count
-	name								= "${var.resource_name_label}-pub-network-sg"
+	name								= "${var.resource_name_label}-pub-network-sg${count.index}"
 	resource_group_name	= azurerm_resource_group.rg[0].name
 	location						= azurerm_resource_group.rg[0].location
 

--- a/Regression_Testbed_TF_Module/modules/testbed-vnet-arm/main.tf
+++ b/Regression_Testbed_TF_Module/modules/testbed-vnet-arm/main.tf
@@ -25,9 +25,9 @@ resource "azurerm_virtual_network" "vnet" {
 }
 
 # ARM Private route table
-resource "azurerm_route_table" "rtb" {
+resource "azurerm_route_table" "pri_rtb" {
 	count 												= var.vnet_count != 0 ? 1 : 0
-	name 													= "${var.resource_name_label}-rtb"
+	name 													= "${var.resource_name_label}-pri-rtb"
 	location 											= azurerm_resource_group.rg[0].location
 	resource_group_name         	= azurerm_resource_group.rg[0].name
 	disable_bgp_route_propagation	= false
@@ -42,10 +42,16 @@ resource "azurerm_route_table" "rtb" {
 }
 
 ##### CHANGE
-resource "azurerm_subnet_route_table_association" "rtb_associate" {
+resource "azurerm_subnet_route_table_association" "pri_rtb_associate1" {
 	count 				 = var.vnet_count
 	subnet_id 		 = azurerm_subnet.private_subnet1[count.index].id
-	route_table_id = azurerm_route_table.rtb[0].id
+	route_table_id = azurerm_route_table.pri_rtb[0].id
+}
+
+resource "azurerm_subnet_route_table_association" "pri_rtb_associate2" {
+	count 				 = var.vnet_count
+	subnet_id 		 = azurerm_subnet.private_subnet2[count.index].id
+	route_table_id = azurerm_route_table.pri_rtb[0].id
 }
 
 # ARM subnet
@@ -54,7 +60,11 @@ resource "azurerm_subnet" "public_subnet1" {
 	name									= "${var.resource_name_label}-pub1-subnet${count.index}"
 	resource_group_name		= azurerm_resource_group.rg[0].name
 	virtual_network_name	= azurerm_virtual_network.vnet[count.index].name
-	address_prefix				= var.pub_subnet1cidr[count.index]
+	address_prefix				= var.pub_subnet1_cidr[count.index]
+
+	lifecycle {
+		ignore_changes = [route_table_id]
+	}
 }
 
 resource "azurerm_subnet" "public_subnet2" {
@@ -63,6 +73,10 @@ resource "azurerm_subnet" "public_subnet2" {
 	resource_group_name		= azurerm_resource_group.rg[0].name
 	virtual_network_name	= azurerm_virtual_network.vnet[count.index].name
 	address_prefix				= var.pub_subnet2_cidr[count.index]
+
+	lifecycle {
+		ignore_changes = [route_table_id]
+	}
 }
 
 resource "azurerm_subnet" "private_subnet1" {
@@ -71,6 +85,10 @@ resource "azurerm_subnet" "private_subnet1" {
 	resource_group_name		= azurerm_resource_group.rg[0].name
 	virtual_network_name	=	azurerm_virtual_network.vnet[count.index].name
 	address_prefix				=	var.pri_subnet1_cidr[count.index]
+
+	lifecycle {
+		ignore_changes = [route_table_id]
+	}
 }
 
 resource "azurerm_subnet" "private_subnet2" {
@@ -79,6 +97,10 @@ resource "azurerm_subnet" "private_subnet2" {
 	resource_group_name		= azurerm_resource_group.rg[0].name
 	virtual_network_name	=	azurerm_virtual_network.vnet[count.index].name
 	address_prefix				=	var.pri_subnet2_cidr[count.index]
+
+	lifecycle {
+		ignore_changes = [route_table_id]
+	}
 }
 
 # ARM Network SG

--- a/Regression_Testbed_TF_Module/modules/testbed-vnet-arm/outputs.tf
+++ b/Regression_Testbed_TF_Module/modules/testbed-vnet-arm/outputs.tf
@@ -10,15 +10,19 @@ output "vnet_name" {
 
 output "subnet_name" {
 	value	= concat(
-		azurerm_subnet.public_subnet[*].name,
-		azurerm_subnet.private_subnet[*].name
+		azurerm_subnet.public_subnet1[*].name,
+		azurerm_subnet.public_subnet2[*].name,
+		azurerm_subnet.private_subnet1[*].name,
+		azurerm_subnet.private_subnet2[*].name
 	)
 }
 
 output "subnet_cidr" {
 	value	= concat(
-		azurerm_subnet.public_subnet[*].address_prefix,
-		azurerm_subnet.private_subnet[*].address_prefix
+		azurerm_subnet.public_subnet1[*].address_prefix,
+		azurerm_subnet.public_subnet2[*].address_prefix,
+		azurerm_subnet.private_subnet1[*].address_prefix,
+		azurerm_subnet.private_subnet2[*].address_prefix
 	)
 }
 


### PR DESCRIPTION
- fixed route table associate switching every terraform apply by ignoring changes to route table id
- private subnet 2 is associated with private route table
- terraform outputs reference the correct terraform resource for subnets